### PR TITLE
Tabs and subtab navigation happens through routes. Also added entity …

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -141,9 +141,14 @@ export const SearchRelevanceApp = ({
             />
             <Switch>
               <Route
-                path={['/']}
+                path={[
+                  '/',
+                  '/:entity(querySet|searchConfiguration|experiment)/:entityAction(list|create|view)?/:entityId?',
+                ]}
                 exact
                 render={(props) => {
+                  const { entity, entityAction, entityId } = props.match.params;
+
                   return (
                     <>
                       {versionModal}
@@ -170,43 +175,14 @@ export const SearchRelevanceApp = ({
                           chrome={chrome}
                           http={http}
                           notifications={notifications}
+                          entity={entity}
+                          entityAction={entityAction}
+                          entityId={entityId}
                         />
                       )}
                     </>
                   );
                 }}
-              />
-              <Route
-                path={['/querySet/create']}
-                render={(props) => (
-                  <QuerySetCreateWithRouter {...props} http={http} notifications={notifications} />
-                )}
-              />
-              <Route
-                path={['/querySet']}
-                render={(props) => <QuerySetListingWithRoute {...props} http={http} />}
-              />
-              <Route
-                path={['/querySet/:id']}
-                render={(props) => <QuerySetView {...props} http={http} />}
-              />
-              <Route
-                path={['/searchConfiguration/create']}
-                render={(props) => (
-                  <SearchConfigurationCreateWithRouter
-                    {...props}
-                    http={http}
-                    notifications={notifications}
-                  />
-                )}
-              />
-              <Route
-                path={['/searchConfiguration/:id']}
-                render={(props) => <SearchConfigurationView {...props} http={http} />}
-              />
-              <Route
-                path={['/searchConfiguration']}
-                render={(props) => <SearchConfigurationListingWithRoute {...props} http={http} />}
               />
             </Switch>
           </>

--- a/public/components/experiment/experiment_page.tsx
+++ b/public/components/experiment/experiment_page.tsx
@@ -10,7 +10,7 @@ import {
 import { GetStartedAccordion } from './get_started_accordion';
 import { Header } from '../common/header';
 import { TemplateCards } from './template_card/template_cards';
-import { ExperimentTabs } from './experiment_tabs';
+import { ExperimentTabsWithRoute } from './experiment_tabs';
 import { experiments, resultListComparisonExperiments } from './mockup_data';
 
 export const ExperimentPage = ({
@@ -18,6 +18,9 @@ export const ExperimentPage = ({
   chrome,
   http,
   notifications,
+  entity,
+  entityAction,
+  entityId,
 }: {
   application: CoreStart['application'];
   chrome: CoreStart['chrome'];
@@ -52,11 +55,14 @@ export const ExperimentPage = ({
               {isTemplateCards ? (
                 <TemplateCards onClose={hideTemplate} />
               ) : (
-                <ExperimentTabs
+                <ExperimentTabsWithRoute
                   experiments={experiments}
                   resultListComparisonExperiments={resultListComparisonExperiments}
                   http={http}
                   notifications={notifications}
+                  entity={entity}
+                  entityAction={entityAction}
+                  entityId={entityId}
                 />
               )}
             </EuiFlexItem>

--- a/public/components/experiment/experiment_tabs.tsx
+++ b/public/components/experiment/experiment_tabs.tsx
@@ -4,14 +4,18 @@
  */
 
 import React, { useState } from 'react';
+import { withRouter } from 'react-router-dom';
 import { EuiTabs, EuiTab, EuiSpacer, EuiPanel } from '@elastic/eui';
 import { ExperimentTabsProps } from './types';
 import { ExperimentTable } from './experiment_table';
 import { SearchConfigurationListingWithRoute } from '../search_config_listing';
 import { QuerySetListingWithRoute } from '../query_set_listing';
 import { QuerySetCreateWithRouter } from '../query_set_create/query_set_create';
+import { QuerySetView } from '../query_set_view/query_set_view';
 import { SearchConfigurationCreateWithRouter } from '../search_config_create/search_config_create';
+import { SearchConfigurationView } from '../search_config_view/search_config_view';
 import { TemplateCards } from './template_card/template_cards';
+import { ExperimentView } from './experiment_view';
 
 const TAB_STYLES = {
   mainTabs: {
@@ -44,15 +48,16 @@ const TAB_STYLES = {
 export const ExperimentTabs = ({
   experiments,
   resultListComparisonExperiments,
+  history,
   http,
   notifications,
+  entity,
+  entityAction,
+  entityId,
 }: ExperimentTabsProps) => {
-  const [selectedMainTabId, setSelectedMainTabId] = useState('experiment');
-  const [selectedSubTabs, setSelectedSubTabs] = useState({
-    experiment: 'list',
-    querySet: 'list',
-    searchConfiguration: 'list',
-  });
+  const selectedMainTabId = entity ? entity : 'experiment';
+  // HACK: we map view to list, because we show the view pane under the list tab
+  const selectedSubTabs = entityAction && entityAction!='view' ? entityAction : 'list';
 
   const mainTabs = [
     { id: 'experiment', name: 'Experiment' },
@@ -65,11 +70,11 @@ export const ExperimentTabs = ({
       {tabs.map((tab) => (
         <EuiTab
           key={tab.id}
-          isSelected={selectedSubTabs[tabKey] === tab.id}
-          onClick={() => setSelectedSubTabs({ ...selectedSubTabs, [tabKey]: tab.id })}
+          isSelected={selectedSubTabs === tab.id}
+          onClick={() => history.push("/" + selectedMainTabId + "/" + tab.id)}
           style={{
             ...TAB_STYLES.subTab,
-            ...(selectedSubTabs[tabKey] === tab.id ? TAB_STYLES.subTabSelected : {}),
+            ...(selectedSubTabs === tab.id ? TAB_STYLES.subTabSelected : {}),
           }}
         >
           {tab.label}
@@ -89,11 +94,15 @@ export const ExperimentTabs = ({
             ])}
             <EuiSpacer size="m" />
             <EuiPanel>
-              {selectedSubTabs.experiment === 'list' ? (
+              {selectedSubTabs === 'list' && entityAction != 'view' ? (
                 <ExperimentTable items={[...experiments, ...resultListComparisonExperiments]} />
-              ) : (
-                <TemplateCards onClose={() => {}} />
-              )}
+              ) : (<></>)}
+              {entityAction === 'view' ? (
+                <ExperimentView http={http} id={entityId} />
+              ) : (<></>)}
+              {selectedSubTabs === 'create' ? (
+                <ExperimentTable items={[...experiments, ...resultListComparisonExperiments]} />
+              ) : (<></>)}
             </EuiPanel>
           </>
         );
@@ -107,11 +116,15 @@ export const ExperimentTabs = ({
             ])}
             <EuiSpacer size="m" />
             <EuiPanel>
-              {selectedSubTabs.querySet === 'list' ? (
+              {selectedSubTabs === 'list' && entityAction != 'view' ? (
                 <QuerySetListingWithRoute http={http} />
-              ) : (
+              ) : (<></>)}
+              {entityAction === 'view' ? (
+                <QuerySetView http={http} id={entityId} />
+              ) : (<></>)}
+              {selectedSubTabs === 'create' ? (
                 <QuerySetCreateWithRouter http={http} notifications={notifications} />
-              )}
+              ) : (<></>)}
             </EuiPanel>
           </>
         );
@@ -125,11 +138,15 @@ export const ExperimentTabs = ({
             ])}
             <EuiSpacer size="m" />
             <EuiPanel>
-              {selectedSubTabs.searchConfiguration === 'list' ? (
+              {selectedSubTabs === 'list' && entityAction != 'view' ? (
                 <SearchConfigurationListingWithRoute http={http} />
-              ) : (
+              ) : (<></>)}
+              {entityAction === 'view' ? (
+                <SearchConfigurationView http={http} id={entityId} />
+              ) : (<></>)}
+              {selectedSubTabs === 'create' ? (
                 <SearchConfigurationCreateWithRouter http={http} notifications={notifications} />
-              )}
+              ) : (<></>)}
             </EuiPanel>
           </>
         );
@@ -147,7 +164,7 @@ export const ExperimentTabs = ({
             <EuiTab
               key={tab.id}
               isSelected={selectedMainTabId === tab.id}
-              onClick={() => setSelectedMainTabId(tab.id)}
+              onClick={() => history.push("/" + tab.id)}
               style={{
                 ...TAB_STYLES.mainTab,
                 ...(selectedMainTabId === tab.id ? TAB_STYLES.mainTabSelected : {}),
@@ -163,3 +180,7 @@ export const ExperimentTabs = ({
     </div>
   );
 };
+
+export const ExperimentTabsWithRoute = withRouter(ExperimentTabs);
+
+export default ExperimentTabsWithRoute;

--- a/public/components/experiment/experiment_view.tsx
+++ b/public/components/experiment/experiment_view.tsx
@@ -8,41 +8,41 @@ import { RouteComponentProps } from 'react-router-dom';
 import { CoreStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../common';
 
-interface QuerySetViewProps extends RouteComponentProps<{ id: string }> {
+interface ExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
 }
 
-export const QuerySetView: React.FC<QuerySetViewProps> = ({ http, id }) => {
-  const [querySet, setQuerySet] = useState<any | null>(null);
+export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id }) => {
+  const [experiment, setExperiment] = useState<any | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
   useEffect(() => {
-    const fetchQuerySet = async () => {
+    const fetchExperiment = async () => {
       try {
         setLoading(true);
-        const response = await http.get(ServiceEndpoints.QuerySets);
+        const response = await http.get(ServiceEndpoints.Experiments);
         const list = response ? response.hits.hits.map((hit: any) => ({ ...hit._source })) : [];
         const filteredList = list.filter((item) => item.id === id);
 
         if (filteredList.length > 0) {
-          setQuerySet(filteredList[0]);
+          setExperiment(filteredList[0]);
         } else {
-          setError('No matching query set found');
+          setError('No matching experiment found');
         }
       } catch (err) {
-        setError('Error loading query set data');
+        setError('Error loading experiment data');
         console.error(err);
       } finally {
         setLoading(false);
       }
     };
 
-    fetchQuerySet();
+    fetchExperiment();
   }, [http, id]);
 
   if (loading) {
-    return <div>Loading query set data...</div>;
+    return <div>Loading experiment data...</div>;
   }
 
   if (error) {
@@ -51,10 +51,10 @@ export const QuerySetView: React.FC<QuerySetViewProps> = ({ http, id }) => {
 
   return (
     <>
-      <h1>Query Set Visualization</h1>
-      <pre>{JSON.stringify(querySet, null, 2)}</pre>
+      <h1>Experiment Visualization</h1>
+      <pre>{JSON.stringify(experiment, null, 2)}</pre>
     </>
   );
 };
 
-export default QuerySetView;
+export default ExperimentView;

--- a/public/components/query_set_listing/query_set_listing.tsx
+++ b/public/components/query_set_listing/query_set_listing.tsx
@@ -73,7 +73,7 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history 
         }
       ) => (
         <>
-          <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `querySet/${querySet.id}`)}>
+          <EuiButtonEmpty size="xs" {...reactRouterNavigate(history, `querySet/view/${querySet.id}`)}>
             {name}
           </EuiButtonEmpty>
         </>

--- a/public/components/search_config_listing/search_config_listing.tsx
+++ b/public/components/search_config_listing/search_config_listing.tsx
@@ -64,7 +64,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `searchConfiguration/${searchConfiguration.id}`)}
+            {...reactRouterNavigate(history, `searchConfiguration/view/${searchConfiguration.id}`)}
           >
             {name}
           </EuiButtonEmpty>

--- a/public/components/search_config_view/search_config_view.tsx
+++ b/public/components/search_config_view/search_config_view.tsx
@@ -13,8 +13,8 @@ interface SearchConfigurationViewProps extends RouteComponentProps<{ id: string 
 }
 
 export const SearchConfigurationView: React.FC<SearchConfigurationViewProps> = ({
-  match,
   http,
+  id,
 }) => {
   const [searchConfiguration, setSearchConfiguration] = useState<any | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
@@ -26,7 +26,7 @@ export const SearchConfigurationView: React.FC<SearchConfigurationViewProps> = (
         setLoading(true);
         const response = await http.get(ServiceEndpoints.SearchConfigurations);
         const list = response ? response.hits.hits.map((hit: any) => ({ ...hit._source })) : [];
-        const filteredList = list.filter((item: any) => item.id === match.params.id);
+        const filteredList = list.filter((item: any) => item.id === id);
 
         if (filteredList.length > 0) {
           setSearchConfiguration(filteredList[0]);
@@ -43,7 +43,7 @@ export const SearchConfigurationView: React.FC<SearchConfigurationViewProps> = (
     };
 
     fetchSearchConfiguration();
-  }, [http, match.params.id]);
+  }, [http, id]);
 
   if (loading) {
     return <div>Loading search configuration data...</div>;

--- a/server/routes/search_relevance_route_service.ts
+++ b/server/routes/search_relevance_route_service.ts
@@ -86,6 +86,13 @@ export function registerSearchRelevanceRoutes(router: IRouter): void {
     },
     backendAction('PUT', BackendEndpoints.Experiments)
   );
+  router.get(
+    {
+      path: ServiceEndpoints.Experiments,
+      validate: false,
+    },
+    backendAction('GET', BackendEndpoints.Experiments)
+  );
 }
 
 const backendAction = (method, path) => {


### PR DESCRIPTION
### Description
Fixes view Query Sets and Search Configurations (still basic pages) and allows viewing with tabs/subtabs.

 * Visualization happens through "/querySet/view/ID" routes.
 * Routes are also associated to other tab/subtab navigation. This enables use of browser history for tab navigation.
 * This also enables having the detailed view page with the tabs/subtabs
 * Added a very basic Experiment view page.

A current downside of this solution is that the view page is shown within the listing tab. It didn't make sense to create a new tab for it, as the user would not be able to click on it without an id. Definitely something to improve on on a subsequent PR.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
