### PR TITLE
fix code editor to not compact json

### DIFF
--- a/public/components/common/DeleteModal.tsx
+++ b/public/components/common/DeleteModal.tsx
@@ -17,7 +17,7 @@ import React from 'react';
 export const DeleteModal = ({ onClose, onConfirm, itemName }) => (
   <EuiModal onClose={onClose}>
     <EuiModalHeader>
-      <EuiModalHeaderTitle>Delete Query Set</EuiModalHeaderTitle>
+      <EuiModalHeaderTitle>Delete Item</EuiModalHeaderTitle>
     </EuiModalHeader>
 
     <EuiModalBody>

--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -223,7 +223,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
             setExperimentToDelete(null);
           }}
           onConfirm={handleDelete}
-          itemName={experimentToDelete.name}
+          itemName={experimentToDelete.id}
         />
       )}
     </EuiPageTemplate>

--- a/public/components/search_config_create/search_config_create.tsx
+++ b/public/components/search_config_create/search_config_create.tsx
@@ -164,7 +164,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
             data-test-subj="createSearchConfigurationButton"
             color="primary"
           >
-            Create Search Configuration
+            Search Configuration
           </EuiButton>,
         ]}
       />
@@ -220,12 +220,10 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
                 value={queryBody}
                 onChange={(value) => {
                   try {
-                    const parsed = JSON.parse(value);
-                    const compactJson = JSON.stringify(parsed);
-                    setQueryBody(compactJson);
+                    JSON.parse(value);
+                    setQueryBody(value);
                     setQueryBodyError('');
                   } catch {
-                    // If it's not valid JSON, just set the value as-is
                     setQueryBody(value);
                   }
                 }}
@@ -238,9 +236,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
                     setQueryBodyError('Query Body is required.');
                   } else {
                     try {
-                      const parsed = JSON.parse(queryBody);
-                      const compactJson = JSON.stringify(parsed);
-                      setQueryBody(compactJson); // Update the value to the compact version
+                      JSON.parse(queryBody);
                       setQueryBodyError('');
                     } catch {
                       setQueryBodyError('Query Body must be valid JSON.');


### PR DESCRIPTION
### Description
- validate with body. search configuration and experiment APIs work fine with json string indent and `\n`
```
{
	"name": "baseline01",
	"index": "sample_index",
	"queryBody": "{\n  \"match_all\": {}\n}",
	"searchPipeline": "n/a"
}
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
