### PR TITLE
add search configuration validation panel to create view

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -46,6 +46,8 @@ export const BASE_NODE_API_PATH = '/api/relevancy';
 export const INDEX_NODE_API_PATH = `${BASE_NODE_API_PATH}/search/indexes`;
 export const SEARCH_PIPELINE_NODE_API_PATH = `${BASE_NODE_API_PATH}/search/pipelines`;
 export const SEARCH_NODE_API_PATH = `${BASE_NODE_API_PATH}/search`;
+export const SINGLE_SEARCH_NODE_API_PATH = `${BASE_NODE_API_PATH}/single_search`;
+
 export const STATS_NODE_API_PATH = `${BASE_NODE_API_PATH}/stats`;
 
 export const DEFAULT_HEADERS = {

--- a/public/components/query_compare/search_result/result_components/result_grid.scss
+++ b/public/components/query_compare/search_result/result_components/result_grid.scss
@@ -80,6 +80,15 @@ doc-table {
   }
 }
 
+/* Alternate row colors */
+.osdDocTable__row:nth-child(even) {
+  background-color: #F5F7FA;
+}
+
+.osdDocTable__row:nth-child(odd) {
+  background-color: #FFFFFF;
+}
+
 .osdDocTable__row--highlight {
   td,
   .osdDocTableRowFilterButton {

--- a/public/components/search_config_create/index.ts
+++ b/public/components/search_config_create/index.ts
@@ -4,3 +4,5 @@
  */
 
 export { SearchConfigurationCreateWithRouter } from './search_config_create';
+export { ResultsPanel } from './results_panel';
+export { ValidationPanel } from './validation_panel';

--- a/public/components/search_config_create/results_panel.tsx
+++ b/public/components/search_config_create/results_panel.tsx
@@ -1,0 +1,98 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React from 'react';
+import { EuiLoadingSpinner, EuiPanel, EuiSpacer } from '@elastic/eui';
+import { uniqueId } from 'lodash';
+
+interface ResultsPanelProps {
+  isValidating: boolean;
+  searchResults: any;
+}
+
+export const ResultsPanel: React.FC<ResultsPanelProps> = ({ isValidating, searchResults }) => {
+  if (isValidating) {
+    return (
+      <EuiPanel>
+        <EuiLoadingSpinner size="l" />
+      </EuiPanel>
+    );
+  }
+
+  if (!searchResults?.hits?.hits || searchResults.hits.hits.length === 0) {
+    return null;
+  }
+
+  const hits = searchResults.hits.hits;
+
+  const getTds = (document: any, documentRank: number) => {
+    const cells = [
+      <td key="rank" className="osdDocTable__cell">
+        {documentRank}
+      </td>,
+      <td key="id" className="osdDocTable__cell">
+        {document._id}
+      </td>,
+    ];
+
+    Object.entries(document._source).forEach(([key, value]) => {
+      cells.push(
+        <td key={key} className="osdDocTable__cell">
+          {String(value)}
+        </td>
+      );
+    });
+
+    return cells;
+  };
+
+  const getHeaders = () => {
+    const firstHit = hits[0];
+    if (!firstHit?._source) return [];
+
+    return [
+      <th key="rank" className="osdDocTable__header">
+        Rank
+      </th>,
+      <th key="id" className="osdDocTable__header">
+        ID
+      </th>,
+      ...Object.keys(firstHit._source).map((key) => (
+        <th key={key} className="osdDocTable__header">
+          {key.charAt(0).toUpperCase() + key.slice(1)}
+        </th>
+      )),
+    ];
+  };
+
+  const resultGrid = () => {
+    return (
+      <>
+        {hits.map((document: any, documentRank: number) => {
+          return (
+            <tr className="osdDocTable__row" key={uniqueId('documentId-')}>
+              {getTds(document, documentRank + 1)}
+            </tr>
+          );
+        })}
+      </>
+    );
+  };
+
+  return (
+    <EuiPanel>
+      <h3>Search Results ({hits.length} hits)</h3>
+      <EuiSpacer size="s" />
+      <div className="dscTable dscTableFixedScroll">
+        <table className="osd-table table" data-test-subj="docTable">
+          <thead>
+            <tr className="osdDocTable__headerRow">{getHeaders()}</tr>
+          </thead>
+          <tbody>{resultGrid()}</tbody>
+        </table>
+      </div>
+    </EuiPanel>
+  );
+};

--- a/public/components/search_config_create/search_config_create.tsx
+++ b/public/components/search_config_create/search_config_create.tsx
@@ -15,12 +15,14 @@ import {
   EuiPageTemplate,
   EuiPanel,
   EuiComboBox,
+  EuiFlexGroup,
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { NotificationsStart } from '../../../../../core/public';
 import { INDEX_NODE_API_PATH, ServiceEndpoints } from '../../../common';
 import { DocumentsIndex } from '../../types';
+import { ValidationPanel } from './validation_panel';
 
 interface SearchConfigurationCreateProps extends RouteComponentProps {
   http: CoreStart['http'];
@@ -108,15 +110,12 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
     http
       .put(ServiceEndpoints.SearchConfigurations, {
         body: JSON.stringify({
-          name: name,
+          name,
           index: selectedIndex[0].label,
-          queryBody: queryBody,
+          queryBody,
         }),
       })
       .then((response) => {
-        console.log('Response:', response);
-        console.log('index', indexOptions);
-        console.log('query_body:', queryBody);
         notifications.toasts.addSuccess(`Search configuration "${name}" created successfully`);
         history.push('/searchConfiguration');
       })
@@ -145,7 +144,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
-        pageTitle="Create Search Configuration"
+        pageTitle="Search Configuration"
         description="Configure a new search configuration with query body and options"
         rightSideItems={[
           <EuiButtonEmpty
@@ -164,114 +163,126 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
             data-test-subj="createSearchConfigurationButton"
             color="primary"
           >
-            Search Configuration
+            Create Search Configuration
           </EuiButton>,
         ]}
       />
-      <EuiPanel hasBorder={true}>
-        <EuiFlexItem>
-          <EuiForm component="form" isInvalid={Boolean(nameError || queryBodyError)}>
-            <EuiFormRow
-              label="Search Configuration Name"
-              error={nameError}
-              isInvalid={Boolean(nameError)}
-              helpText="A unique name for this search configuration"
-              fullWidth
-            >
-              <EuiFieldText
-                placeholder="Enter search configuration name"
-                value={name}
-                onChange={(e) => setName(e.target.value)}
-                onBlur={validateName}
-                isInvalid={Boolean(nameError)}
-                fullWidth
-                data-test-subj="searchConfigurationNameInput"
-              />
-            </EuiFormRow>
+      <EuiFlexGroup>
+        <EuiFlexItem grow={7}>
+          <EuiPanel hasBorder={true}>
+            <EuiFlexItem>
+              <EuiForm component="form" isInvalid={Boolean(nameError || queryBodyError)}>
+                <EuiFormRow
+                  label="Search Configuration Name"
+                  error={nameError}
+                  isInvalid={Boolean(nameError)}
+                  helpText="A unique name for this search configuration"
+                  fullWidth
+                >
+                  <EuiFieldText
+                    placeholder="Enter search configuration name"
+                    value={name}
+                    onChange={(e) => setName(e.target.value)}
+                    onBlur={validateName}
+                    isInvalid={Boolean(nameError)}
+                    fullWidth
+                    data-test-subj="searchConfigurationNameInput"
+                  />
+                </EuiFormRow>
 
-            <EuiFormRow
-              label="Index"
-              helpText="Select an index for this search configuration"
-              fullWidth
-            >
-              <EuiComboBox
-                placeholder="Select an index"
-                options={indexOptions}
-                selectedOptions={selectedIndex}
-                onChange={(selected) => setSelectedIndex(selected)}
-                isClearable={true}
-                isLoading={isLoadingIndexes}
-                singleSelection={{ asPlainText: true }}
-                fullWidth
-              />
-            </EuiFormRow>
+                <EuiFormRow
+                  label="Index"
+                  helpText="Select an index for this search configuration"
+                  fullWidth
+                >
+                  <EuiComboBox
+                    placeholder="Select an index"
+                    options={indexOptions}
+                    selectedOptions={selectedIndex}
+                    onChange={(selected) => setSelectedIndex(selected)}
+                    isClearable={true}
+                    isLoading={isLoadingIndexes}
+                    singleSelection={{ asPlainText: true }}
+                    fullWidth
+                  />
+                </EuiFormRow>
 
-            <EuiFormRow
-              label="Query Body"
-              error={queryBodyError}
-              isInvalid={Boolean(queryBodyError)}
-              helpText="Define the query body in JSON format"
-              fullWidth
-            >
-              <EuiCodeEditor
-                mode="json"
-                theme="github"
-                width="100%"
-                value={queryBody}
-                onChange={(value) => {
-                  try {
-                    JSON.parse(value);
-                    setQueryBody(value);
-                    setQueryBodyError('');
-                  } catch {
-                    setQueryBody(value);
-                  }
-                }}
-                setOptions={{
-                  showLineNumbers: true,
-                  tabSize: 2,
-                }}
-                onBlur={() => {
-                  if (!queryBody.trim()) {
-                    setQueryBodyError('Query Body is required.');
-                  } else {
-                    try {
-                      JSON.parse(queryBody);
-                      setQueryBodyError('');
-                    } catch {
-                      setQueryBodyError('Query Body must be valid JSON.');
-                    }
-                  }
-                }}
-                isInvalid={Boolean(queryBodyError)}
-                aria-label="Code Editor"
-              />
-            </EuiFormRow>
+                <EuiFormRow
+                  label="Query Body"
+                  error={queryBodyError}
+                  isInvalid={Boolean(queryBodyError)}
+                  helpText="Define the query body in JSON format"
+                  fullWidth
+                >
+                  <EuiCodeEditor
+                    mode="json"
+                    theme="github"
+                    width="100%"
+                    value={queryBody}
+                    onChange={(value) => {
+                      try {
+                        JSON.parse(value);
+                        setQueryBody(value);
+                        setQueryBodyError('');
+                      } catch {
+                        setQueryBody(value);
+                      }
+                    }}
+                    setOptions={{
+                      showLineNumbers: true,
+                      tabSize: 2,
+                    }}
+                    onBlur={() => {
+                      if (!queryBody.trim()) {
+                        setQueryBodyError('Query Body is required.');
+                      } else {
+                        try {
+                          JSON.parse(queryBody);
+                          setQueryBodyError('');
+                        } catch {
+                          setQueryBodyError('Query Body must be valid JSON.');
+                        }
+                      }
+                    }}
+                    isInvalid={Boolean(queryBodyError)}
+                    aria-label="Code Editor"
+                  />
+                </EuiFormRow>
 
-            <EuiFormRow
-              label="Search Pipeline"
-              helpText="Define the search pipeline to be used"
-              fullWidth
-            >
-              <EuiFieldText
-                placeholder="Enter search pipeline"
-                value={searchPipeline}
-                onChange={(e) => setSearchPipeline(e.target.value)}
-                fullWidth
-              />
-            </EuiFormRow>
+                <EuiFormRow
+                  label="Search Pipeline"
+                  helpText="Define the search pipeline to be used"
+                  fullWidth
+                >
+                  <EuiFieldText
+                    placeholder="Enter search pipeline"
+                    value={searchPipeline}
+                    onChange={(e) => setSearchPipeline(e.target.value)}
+                    fullWidth
+                  />
+                </EuiFormRow>
 
-            <EuiFormRow label="Search Template" helpText="Define the search template" fullWidth>
-              <EuiFieldText
-                placeholder="Enter search template"
-                value={searchTemplate}
-                onChange={(e) => setSearchTemplate(e.target.value)}
-                fullWidth
-              />
-            </EuiFormRow>
-          </EuiForm>
+                <EuiFormRow label="Search Template" helpText="Define the search template" fullWidth>
+                  <EuiFieldText
+                    placeholder="Enter search template"
+                    value={searchTemplate}
+                    onChange={(e) => setSearchTemplate(e.target.value)}
+                    fullWidth
+                  />
+                </EuiFormRow>
+              </EuiForm>
+            </EuiFlexItem>
+          </EuiPanel>
         </EuiFlexItem>
-      </EuiPanel>
+        <EuiFlexItem grow={5}>
+          <ValidationPanel
+            selectedIndex={selectedIndex}
+            queryBody={queryBody}
+            http={http}
+            notifications={notifications}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
     </EuiPageTemplate>
   );
 };

--- a/public/components/search_config_create/validation_panel.tsx
+++ b/public/components/search_config_create/validation_panel.tsx
@@ -1,0 +1,106 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { EuiFieldText, EuiSpacer, EuiPanel, EuiButton, EuiFlexItem } from '@elastic/eui';
+import { NotificationsStart } from '../../../../../core/public';
+import { SINGLE_SEARCH_NODE_API_PATH } from '../../../common';
+import { ResultsPanel } from './results_panel';
+
+interface ValidationPanelProps {
+  selectedIndex: Array<{ label: string }>;
+  queryBody: string;
+  http: CoreStart['http'];
+  notifications: NotificationsStart;
+}
+
+export const ValidationPanel: React.FC<ValidationPanelProps> = ({
+  selectedIndex,
+  queryBody,
+  http,
+  notifications,
+}) => {
+  const [testSearchText, setTestSearchText] = useState('');
+  const [isValidating, setIsValidating] = useState(false);
+  const [searchResults, setSearchResults] = useState(null);
+
+  const validateSearchQuery = async () => {
+    if (!selectedIndex.length) {
+      notifications.toasts.addError('Please select an index');
+      return;
+    }
+
+    if (!queryBody.trim()) {
+      notifications.toasts.addError('Query body is required');
+      return;
+    }
+
+    try {
+      setIsValidating(true);
+      const replacedQueryBody = queryBody.replace(/%SearchText%/g, testSearchText || '');
+      const parsedQuery = JSON.parse(replacedQueryBody);
+
+      const requestBody = {
+        query: {
+          index: selectedIndex[0].label,
+          size: 5, // hard-coded to return 5 items
+          query: parsedQuery,
+        },
+      };
+
+      const response = await http.post(SINGLE_SEARCH_NODE_API_PATH, {
+        body: JSON.stringify(requestBody),
+      });
+
+      if (!response || !response.result) {
+        throw new Error('Search returned no results');
+      }
+
+      setSearchResults(response.result);
+      notifications.toasts.addSuccess('Search query is valid');
+    } catch (error) {
+      let errorMessage = 'Failed to validate search query';
+      if (error.body?.message) {
+        errorMessage = error.body.message;
+      } else if (error.message) {
+        errorMessage = error.message;
+      }
+      // Add warning toast instead of error since it's not a blocker
+      notifications.toasts.addWarning({
+        title: 'Validation Warning',
+        text: errorMessage,
+        toastLifeTimeMs: 5000, // 5 seconds display time
+      });
+      setSearchResults(null);
+    } finally {
+      setIsValidating(false);
+    }
+  };
+
+  return (
+    <EuiFlexItem>
+      <EuiFieldText
+        placeholder="Enter a text to replace %SearchText% for testing ..."
+        value={testSearchText}
+        onChange={(e) => setTestSearchText(e.target.value)}
+        fullWidth
+        data-test-subj="testSearchTextInput"
+      />
+      <EuiSpacer size="m" />
+      <EuiPanel hasBorder={true}>
+        <EuiButton
+          onClick={validateSearchQuery}
+          fullWidth
+          iconType="check"
+          data-test-subj="validateSearchQueryButton"
+        >
+          Validate Search Configuration
+        </EuiButton>
+        <EuiSpacer size="l" />
+        <ResultsPanel isValidating={isValidating} searchResults={searchResults} />
+      </EuiPanel>
+    </EuiFlexItem>
+  );
+};

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -12,6 +12,7 @@ import {
   SEARCH_API,
   SEARCH_NODE_API_PATH,
   SEARCH_PIPELINE_NODE_API_PATH,
+  SINGLE_SEARCH_NODE_API_PATH,
 } from '../../common';
 import { METRIC_ACTION, METRIC_NAME } from '../metrics';
 
@@ -20,6 +21,11 @@ interface SearchResultsResponse {
   result2?: any;
   errorMessage1?: any;
   errorMessage2?: any;
+}
+
+interface SearchResultResponse {
+  result: any;
+  errorMsg: any;
 }
 
 // eslint-disable-next-line @typescript-eslint/no-var-requires
@@ -56,27 +62,33 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         try {
           let resp;
           const invalidCharactersPattern = /[\s,:\"*+\/\\|?#><]/;
-          if (index !== index.toLowerCase() || index.startsWith('_') || index.startsWith('-') || invalidCharactersPattern.test(index)) {
+          if (
+            index !== index.toLowerCase() ||
+            index.startsWith('_') ||
+            index.startsWith('-') ||
+            invalidCharactersPattern.test(index)
+          ) {
             resBody.errorMessage1 = {
               statusCode: 400,
               body: 'Invalid Index or missing',
             };
           }
-          if (pipeline !== '*' && pipeline !== '_none'  && pipeline !== '' && !(/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline))){
+          if (
+            pipeline !== '*' &&
+            pipeline !== '_none' &&
+            pipeline !== '' &&
+            !/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline)
+          ) {
             resBody.errorMessage1 = {
               statusCode: 400,
               body: 'Invalid Pipepline',
             };
           }
-          if(dataSourceEnabled && dataSourceId1){
+          if (dataSourceEnabled && dataSourceId1) {
             const client = context.dataSource.opensearch.legacy.getClient(dataSourceId1);
             resp = await client.callAPI('search', params);
-          }
-          else{
-              resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
-                'search',
-                params
-              );
+          } else {
+            resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
           }
           const end = performance.now();
           context.searchRelevance.metricsService.addMetric(
@@ -127,24 +139,30 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         try {
           let resp;
           const invalidCharactersPattern = /[\s,:\"*+\/\\|?#><]/;
-          if (index !== index.toLowerCase() || index.startsWith('_') || index.startsWith('-') || invalidCharactersPattern.test(index)) {
-            throw new Error("Index invalid or missing.");
+          if (
+            index !== index.toLowerCase() ||
+            index.startsWith('_') ||
+            index.startsWith('-') ||
+            invalidCharactersPattern.test(index)
+          ) {
+            throw new Error('Index invalid or missing.');
           }
-          if (pipeline !== '*' && pipeline !== '_none'  && pipeline !== '' && !(/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline))){
+          if (
+            pipeline !== '*' &&
+            pipeline !== '_none' &&
+            pipeline !== '' &&
+            !/^[a-zA-Z0-9_\-*]+(,[a-zA-Z0-9_\-*]+)*$/.test(pipeline)
+          ) {
             resBody.errorMessage1 = {
               statusCode: 400,
               body: 'Invalid Pipepline',
             };
           }
-          if(dataSourceEnabled && dataSourceId2){
+          if (dataSourceEnabled && dataSourceId2) {
             const client = context.dataSource.opensearch.legacy.getClient(dataSourceId2);
             resp = await client.callAPI('search', params);
-          }
-          else{
-              resp = await context.core.opensearch.legacy.client.callAsCurrentUser(
-                'search',
-                params
-              );
+          } else {
+            resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
           }
           const end = performance.now();
           context.searchRelevance.metricsService.addMetric(
@@ -186,7 +204,7 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       path: `${INDEX_NODE_API_PATH}/{dataSourceId?}`,
       validate: {
         params: schema.object({
-          dataSourceId: schema.maybe(schema.string({ defaultValue: '' }))
+          dataSourceId: schema.maybe(schema.string({ defaultValue: '' })),
         }),
       },
     },
@@ -196,9 +214,9 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       };
       const start = performance.now();
       try {
-        const dataSourceId  = request.params.dataSourceId;
+        const dataSourceId = request.params.dataSourceId;
         let callApi: ILegacyScopedClusterClient['callAsCurrentUser'];
-        if(dataSourceEnabled && dataSourceId){
+        if (dataSourceEnabled && dataSourceId) {
           callApi = context.dataSource.opensearch.legacy.getClient(dataSourceId).callAPI;
         } else {
           callApi = context.core.opensearch.legacy.client.callAsCurrentUser;
@@ -237,7 +255,7 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       path: `${SEARCH_PIPELINE_NODE_API_PATH}/{dataSourceId?}`,
       validate: {
         params: schema.object({
-          dataSourceId: schema.maybe(schema.string({ defaultValue: '' }))
+          dataSourceId: schema.maybe(schema.string({ defaultValue: '' })),
         }),
       },
     },
@@ -249,15 +267,14 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       let resBody: any = {};
       let resp;
       try {
-        const dataSourceId  = request.params.dataSourceId;
-        if(dataSourceEnabled && dataSourceId){
-          resp = (await context.dataSource.opensearch.getClient(dataSourceId)).transport
+        const dataSourceId = request.params.dataSourceId;
+        if (dataSourceEnabled && dataSourceId) {
+          resp = (await context.dataSource.opensearch.getClient(dataSourceId)).transport;
           resp = await resp.request({
             method: 'GET',
             path: `${SEARCH_API}/pipeline`,
-          })
-        }
-        else{
+          });
+        } else {
           resp = await context.core.opensearch.client.asCurrentUser.transport.request({
             method: 'GET',
             path: `${SEARCH_API}/pipeline`,
@@ -288,6 +305,49 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
           body: error,
         });
       }
+    }
+  );
+
+  router.post(
+    {
+      path: SINGLE_SEARCH_NODE_API_PATH,
+      validate: { body: schema.any() },
+    },
+    async (context, request, response) => {
+      const { query, dataSourceId } = request.body;
+      const resBody: SearchResultResponse = {};
+
+      const { index, size, ...rest } = query;
+      const params: RequestParams.Search = {
+        index,
+        size,
+        body: rest,
+      };
+
+      try {
+        // Execute search
+        let resp;
+        if (dataSourceEnabled && dataSourceId) {
+          const client = context.dataSource.opensearch.legacy.getClient(dataSourceId);
+          resp = await client.callAPI('search', params);
+        } else {
+          resp = await context.core.opensearch.legacy.client.callAsCurrentUser('search', params);
+        }
+
+        resBody.result = resp;
+      } catch (error) {
+        if (error.statusCode !== 404) console.error(error);
+
+        const errorMessage = `Error: ${error.body?.error?.type} - ${error.body?.error?.reason}`;
+        resBody.errorMsg = {
+          statusCode: error.statusCode || 500,
+          body: errorMessage,
+        };
+      }
+
+      return response.ok({
+        body: resBody,
+      });
     }
   );
 }


### PR DESCRIPTION
### Description
- during search configuration create view, users might want to validate the queryBody, index and searchPipeline are setup correctly before creation.
- adding a validation panel to do simply validation 
  - do a real search against the configurations with 
     - a testing SearchText
     - a defaulted size = 5

<img width="1592" alt="Screenshot 2025-04-18 at 2 36 34 PM" src="https://github.com/user-attachments/assets/551b9e46-35b3-491c-a432-ae7fabbeacb6" />



### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
