### PR TITLE
add the missing s to pptss

### DIFF
--- a/public/components/query_set_create/query_set_create.tsx
+++ b/public/components/query_set_create/query_set_create.tsx
@@ -47,7 +47,7 @@ export const QuerySetCreate: React.FC<QuerySetCreateProps> = ({ http, notificati
 
   const samplingOptions = [
     { value: 'random', text: 'Random' },
-    { value: 'ppts', text: 'Probability-Proportional-to-Size Sampling' },
+    { value: 'pptss', text: 'Probability-Proportional-to-Size Sampling' },
     { value: 'topn', text: 'Top N' },
   ];
 


### PR DESCRIPTION
### Description
Fix typo that prevents `pptss` sampling method from running successfully.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
