### PR TITLE
UI corrections

### DIFF
--- a/public/application.tsx
+++ b/public/application.tsx
@@ -10,6 +10,7 @@ import { DataSourceManagementPluginSetup } from '../../../src/plugins/data_sourc
 import { SearchRelevanceApp } from './components/app';
 import { AppPluginStartDependencies } from './types';
 import { OpenSearchDashboardsContextProvider } from '../../../src/plugins/opensearch_dashboards_react/public';
+import { ConfigProvider } from './contexts/date_format_context';
 
 export const renderApp = (
   coreStart: CoreStart,
@@ -17,22 +18,24 @@ export const renderApp = (
   { element, setHeaderActionMenu, history }: AppMountParameters,
   dataSourceManagement: DataSourceManagementPluginSetup
 ) => {
-  const { notifications, http, chrome, savedObjects, application } = coreStart;
+  const { notifications, http, chrome, savedObjects, application, uiSettings } = coreStart;
 
   ReactDOM.render(
     <OpenSearchDashboardsContextProvider services={coreStart}>
-      <SearchRelevanceApp
-        notifications={notifications}
-        http={http}
-        navigation={navigation}
-        chrome={chrome}
-        savedObjects={savedObjects}
-        dataSourceEnabled={!!dataSource}
-        setActionMenu={setHeaderActionMenu}
-        dataSourceManagement={dataSourceManagement}
-        application={application}
-        history={history}
-      />
+      <ConfigProvider uiSettings={uiSettings}>
+        <SearchRelevanceApp
+          notifications={notifications}
+          http={http}
+          navigation={navigation}
+          chrome={chrome}
+          savedObjects={savedObjects}
+          dataSourceEnabled={!!dataSource}
+          setActionMenu={setHeaderActionMenu}
+          dataSourceManagement={dataSourceManagement}
+          application={application}
+          history={history}
+        />
+      </ConfigProvider>
     </OpenSearchDashboardsContextProvider>,
     element
   );

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -15,7 +15,7 @@ import { ConfigProvider } from './contexts/date_format_context';
 export const renderApp = (
   coreStart: CoreStart,
   { navigation, dataSource }: AppPluginStartDependencies,
-  { element, setHeaderActionMenu, history }: AppMountParameters,
+  { element, setHeaderActionMenu }: AppMountParameters,
   dataSourceManagement: DataSourceManagementPluginSetup
 ) => {
   const { notifications, http, chrome, savedObjects, application, uiSettings } = coreStart;
@@ -33,7 +33,6 @@ export const renderApp = (
           setActionMenu={setHeaderActionMenu}
           dataSourceManagement={dataSourceManagement}
           application={application}
-          history={history}
         />
       </ConfigProvider>
     </OpenSearchDashboardsContextProvider>,

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -35,7 +35,6 @@ interface SearchRelevanceAppDeps {
   dataSourceManagement: DataSourceManagementPluginSetup;
   setActionMenu: (menuMount: MountPoint | undefined) => void;
   application: CoreStart['application'];
-  history: CoreStart['history'];
 }
 
 export const SearchRelevanceApp = ({
@@ -48,7 +47,6 @@ export const SearchRelevanceApp = ({
   setActionMenu,
   dataSourceManagement,
   application,
-  history,
 }: SearchRelevanceAppDeps) => {
   const [toasts, setToasts] = useState<Toast[]>([]);
   const [toastRightSide, setToastRightSide] = useState<boolean>(true);

--- a/public/components/common/header.tsx
+++ b/public/components/common/header.tsx
@@ -24,7 +24,7 @@ export const Header = ({ children }: HeaderProps) => {
       </EuiTitle>
       <EuiText>
         <p>
-          Evaluate on your search quality with different queries.{' '}
+          Evaluate your search quality with different queries.{' '}
           <EuiLink
             href="https://opensearch.org/docs/latest/search-plugins/search-relevance"
             target="_blank"

--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -21,12 +21,15 @@ import { CoreStart } from '../../../../../src/core/public';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
+import { useConfig } from '../../contexts/date_format_context';
+import moment from 'moment';
 
 interface ExperimentListingProps extends RouteComponentProps {
   http: CoreStart['http'];
 }
 
 export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, history }) => {
+  const { dateFormat } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -105,7 +108,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
       dataType: 'string',
       sortable: true,
       render: (timestamp: string) => (
-        <EuiText size="s">{new Date(timestamp).toLocaleString()}</EuiText>
+        <EuiText size="s">{moment(timestamp).format(dateFormat)}</EuiText>
       ),
     },
     {

--- a/public/components/experiment_view/experiment_view.tsx
+++ b/public/components/experiment_view/experiment_view.tsx
@@ -159,6 +159,15 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id }) => {
             name: cheatColNames[metricName],
             dataType: 'number',
             sortable: true,
+            render: (value) => {
+              if (value !== undefined && value !== null) {
+                return new Intl.NumberFormat(undefined, {
+                  minimumFractionDigits: 2,
+                  maximumFractionDigits: 2,
+                }).format(value);
+              }
+              return '-';
+            }
           })
         }
       })

--- a/public/components/query_set_listing/query_set_listing.tsx
+++ b/public/components/query_set_listing/query_set_listing.tsx
@@ -23,12 +23,15 @@ import {
 import { CoreStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
+import { useConfig } from '../../contexts/date_format_context';
+import moment from 'moment';
 
 interface QuerySetListingProps extends RouteComponentProps {
   http: CoreStart['http'];
 }
 
 export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history }) => {
+  const { dateFormat } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -106,7 +109,7 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history 
       dataType: 'string',
       sortable: true,
       render: (timestamp: string) => (
-        <EuiText size="s">{new Date(timestamp).toLocaleString()}</EuiText>
+        <EuiText size="s">{moment(timestamp).format(dateFormat)}</EuiText>
       ),
     },
     {

--- a/public/components/search_config_listing/search_config_listing.tsx
+++ b/public/components/search_config_listing/search_config_listing.tsx
@@ -21,6 +21,8 @@ import { CoreStart } from '../../../../../src/core/public';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
+import { useConfig } from '../../contexts/date_format_context';
+import moment from 'moment';
 
 interface SearchConfigurationListingProps extends RouteComponentProps {
   http: CoreStart['http'];
@@ -30,6 +32,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
   http,
   history,
 }) => {
+  const { dateFormat } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
@@ -94,7 +97,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
       dataType: 'string',
       sortable: true,
       render: (timestamp: string) => (
-        <EuiText size="s">{new Date(timestamp).toLocaleString()}</EuiText>
+        <EuiText size="s">{moment(timestamp).format(dateFormat)}</EuiText>
       ),
     },
     {

--- a/public/contexts/date_format_context.tsx
+++ b/public/contexts/date_format_context.tsx
@@ -1,0 +1,31 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { createContext, useContext } from 'react';
+import { CoreStart } from '../../../src/core/public';
+
+interface ConfigContextProps {
+  dateFormat: string;
+  // Add other config fields here as needed
+}
+
+const ConfigContext = createContext<ConfigContextProps>({
+  dateFormat: 'MMM D, YYYY @ HH:mm:ss.SSS', // Default format
+});
+
+export const useConfig = () => useContext(ConfigContext);
+
+export const ConfigProvider: React.FC<{
+  uiSettings: CoreStart['uiSettings'];
+  children: React.ReactNode;
+}> = ({ uiSettings, children }) => {
+  const dateFormat = uiSettings.get('dateFormat') || 'MMM D, YYYY @ HH:mm:ss.SSS';
+
+  return (
+    <ConfigContext.Provider value={{ dateFormat }}>
+      {children}
+    </ConfigContext.Provider>
+  );
+}; 


### PR DESCRIPTION
### Description
The following is addressed:
 * Main page: "Evaluate on", delete "on"
 * Use US timestamp formatting (actually use OpenSearch Dashboards configured date formatting)
 * Formatting of metrics, always use two decimals (e.g. no 0 or 1 or 0.4) (in the screenshot renders using the locale of my laptop: DE)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

<img width="1457" alt="Screenshot 2025-04-22 at 18 47 02" src="https://github.com/user-attachments/assets/3d0c6778-3950-4d86-9d34-2c0d1f66b9f4" />
<img width="1215" alt="Screenshot 2025-04-22 at 18 47 17" src="https://github.com/user-attachments/assets/c393dbce-c9e6-4ae3-86fd-c32d975e1bae" />
