### PR TITLE
UI corrections

### DIFF
--- a/public/components/experiment_view/experiment_view.tsx
+++ b/public/components/experiment_view/experiment_view.tsx
@@ -262,6 +262,9 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id }) => {
         <VisualComparison
           queryResult1={convertFromSearchResult(queryResult1)}
           queryResult2={convertFromSearchResult(queryResult2)}
+          queryText={queryEntries[selectedQuery].queryText}
+          resultText1="Result 1"
+          resultText2="Result 2"
         />
       ) : (<></>)}
 

--- a/public/components/query_compare/search_result/index.tsx
+++ b/public/components/query_compare/search_result/index.tsx
@@ -292,6 +292,9 @@ const versionToggle = (
               queryResult2={convertFromSearchResult(queryResult2)}
               queryError1={queryError1}
               queryError2={queryError2}
+              queryText={searchBarValue}
+              resultText1="Result 1"
+              resultText2="Result 2"
             />
         )}
       </EuiPageContentBody>

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
@@ -44,6 +44,10 @@
   margin-right: 0.5rem;
 }
 
+.ml-2 {
+  margin-left: 0.5rem;
+}
+
 .mr-3 {
   margin-right: 0.75rem;
 }
@@ -71,6 +75,10 @@
 }
 
 /* Typography */
+.text-right {
+  text-align: right;
+}
+
 .text-xs {
   font-size: 0.75rem;
   line-height: 1rem;
@@ -121,6 +129,11 @@
 /* Flexbox layouts */
 .flex {
   display: flex;
+}
+
+.flex-row-reverse {
+  display: flex;
+  flex-direction: row-reverse;
 }
 
 .flex-1 {

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
@@ -520,3 +520,91 @@ svg line {
     overflow: auto;
   }
 }
+
+/* Venn diagram styles for OpenSearch comparison */
+.venn-container {
+  position: relative;
+  height: 80px;
+  margin: 2rem auto;
+  max-width: 48rem; /* max-w-3xl */
+}
+
+.venn-left {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-87%); // -100 + 27 = -73
+  background-color: rgba(254, 249, 195, 0.9); /* bg-yellow-100 with opacity */
+  width: 22rem; // 14rem; /* w-56 */
+  height: 6rem; /* h-32 */
+  border-radius: 1rem; /* rounded-lg */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); /* shadow-md */
+  z-index: 10;
+}
+
+.venn-middle {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-50%);
+  background-color: rgba(219, 234, 254, 0.7); /* bg-blue-100 with opacity */
+  width: 6rem; /* w-24 */
+  height: 6rem; /* h-32 */
+  border-radius: 1rem; /* rounded-lg */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  border: 1px solid white;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); /* shadow-md */
+  z-index: 12;
+}
+
+.venn-right {
+  position: absolute;
+  left: 50%;
+  transform: translateX(-13%);
+  background-color: rgba(233, 213, 255, 0.9); /* bg-purple-100 with opacity */
+  width: 22rem; //14rem; /* w-56 */
+  height: 6rem; /* h-32 */
+  border-radius: 1rem; /* rounded-lg */
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  box-shadow: 0 4px 6px -1px rgba(0, 0, 0, 0.1); /* shadow-md */
+  z-index: 11;
+}
+
+.venn-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  margin-bottom: 0.25rem;
+}
+
+.venn-label {
+  font-size: 0.875rem;
+  text-align: center;
+}
+
+/* Responsive adjustments */
+@media (max-width: 640px) {
+  .venn-container {
+    height: 10rem;
+  }
+
+  .venn-left, .venn-right, .venn-middle {
+    width: 10rem;
+    height: 5rem;
+  }
+
+  .venn-left {
+    transform: translateX(-60%);
+  }
+
+  .venn-right {
+    transform: translateX(-40%);
+  }
+}

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -308,26 +308,26 @@ export const VisualComparison = ({
         </select>
       </div>
       
-      {/* Summary section with card style */}
+      {/* Summary section with Venn diagram style using CSS classes */}
       <div className="mb-6">
         <h3 className="text-lg font-semibold mb-4">Summary</h3>
-        <div className="flex justify-between gap-4">
-          {/* Common items card */}
-          <div className="flex-1 bg-blue-50 p-6 rounded-lg text-center">
-            <div className="text-xl font-bold mb-2">{statistics.inBoth}</div>
-            <div>Common items</div>
+        <div className="venn-container">
+          {/* Result 1 rectangle (left) */}
+          <div className="venn-left">
+            <div className="venn-value">{statistics.onlyInResult1}</div>
+            <div className="venn-label">Unique</div>
           </div>
           
-          {/* Unique to Result 1 card */}
-          <div className="flex-1 bg-yellow-50 p-6 rounded-lg text-center">
-            <div className="text-xl font-bold mb-2">{statistics.onlyInResult1}</div>
-            <div>Unique to Result 1</div>
+          {/* Intersection (middle) */}
+          <div className="venn-middle">
+            <div className="venn-value">{statistics.inBoth}</div>
+            <div className="venn-label">Common</div>
           </div>
           
-          {/* Unique to Result 2 card */}
-          <div className="flex-1 bg-purple-50 p-6 rounded-lg text-center">
-            <div className="text-xl font-bold mb-2">{statistics.onlyInResult2}</div>
-            <div>Unique to Result 2</div>
+          {/* Result 2 rectangle (right) */}
+          <div className="venn-right">
+            <div className="venn-value">{statistics.onlyInResult2}</div>
+            <div className="venn-label">Unique</div>
           </div>
         </div>
       </div>

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -516,6 +516,27 @@ export const VisualComparison = ({
           onMouseEnter={() => handleItemMouseEnter(hoveredItem)}
           onMouseLeave={handleItemMouseLeave}
         >
+
+          {imageFieldName && hoveredItem[imageFieldName] && hoveredItem[imageFieldName].match(/\.(jpg|jpeg|png|gif|svg|webp)($|\?)/i) ? (
+            <>
+              <div className="flex items-center mb-2">
+                <div className="w-16 h-16 flex-shrink-0 mr-3">
+                  <img
+                    width="16"
+                    height="16"
+                    src={hoveredItem[imageFieldName]}
+                    className="w-16 h-16 object-cover rounded"
+                  />
+                </div>
+                { /* hoveredItem.title && (<h3 className="text-lg font-bold">{hoveredItem.title}</h3>)} */}
+              </div>
+              <div className="border-t border-b py-2 mb-2"></div>
+            </>
+          ) : (
+            <></>
+          )}
+
+
           <div className="grid grid-cols-2 gap-2">
             <div className="mb-1 text-sm">
               <span className="font-semibold">ID:</span> <span className="font-mono">{hoveredItem._id}</span>

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -354,14 +354,14 @@ export const VisualComparison = ({
                 key={`r1-${index}`}
                 id={`r1-item-${item._id}`}
                 ref={el => result1ItemsRef.current[item._id] = el}
-                className="flex items-center mb-2 hover:bg-gray-100 p-1 rounded"
+                className="flex-row-reverse items-center mb-2 hover:bg-gray-100 p-1 rounded"
                 onMouseEnter={() => handleItemMouseEnter(item)}
                 onMouseLeave={handleItemMouseLeave}
               >
-                <div className={`w-8 h-8 rounded-full ${getStatusColor(item, 1)} flex items-center justify-center font-bold mr-2`}>
+                <div className={`w-8 h-8 rounded-full ${getStatusColor(item, 1)} flex items-center justify-center font-bold ml-2`}>
                   {item.rank}
                 </div>
-                <div className="w-8 h-8 mr-2 flex-shrink-0">
+                <div className="w-8 h-8 ml-2 flex-shrink-0">
                   {imageFieldName && item[imageFieldName] && item[imageFieldName].match(/\.(jpg|jpeg|png|gif|svg|webp)($|\?)/i) ? (
                     <img
                       width="32"
@@ -375,7 +375,7 @@ export const VisualComparison = ({
                     />
                   )}
                 </div>
-                <div className="font-mono text-sm truncate flex-grow">
+                <div className="font-mono text-sm truncate flex-grow text-right">
                   {item[displayField] || item._id}
                 </div>
               </div>

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -358,7 +358,7 @@ export const VisualComparison = ({
                 onMouseEnter={() => handleItemMouseEnter(item)}
                 onMouseLeave={handleItemMouseLeave}
               >
-                <div className={`w-8 h-8 rounded-full ${getStatusColor(item, 1)} flex items-center justify-center font-bold ml-2`}>
+                <div className={`w-8 h-8 rounded-full ${getStatusColor(item, 1)} flex items-center justify-center font-bold ml-2 flex-shrink-0`}>
                   {item.rank}
                 </div>
                 <div className="w-8 h-8 ml-2 flex-shrink-0">
@@ -458,7 +458,7 @@ export const VisualComparison = ({
                 onMouseEnter={() => handleItemMouseEnter(item)}
                 onMouseLeave={handleItemMouseLeave}
               >
-                <div className={`w-8 h-8 rounded-full ${getStatusColor(item, 2)} flex items-center justify-center font-bold mr-2`}>
+                <div className={`w-8 h-8 rounded-full ${getStatusColor(item, 2)} flex items-center justify-center font-bold mr-2 flex-shrink-0`}>
                   {item.rank}
                 </div>
                 <div className="w-8 h-8 mr-2 flex-shrink-0">

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -9,6 +9,9 @@ interface OpenSearchComparisonProps {
   queryResult2: any;
   queryError1: any;
   queryError2: any;
+  queryText: string;
+  resultText1: string;
+  resultText2: string;
 }
 
 export const convertFromSearchResult = (searchResult) => {
@@ -27,6 +30,9 @@ export const VisualComparison = ({
   queryResult2,
   queryError1,
   queryError2,
+  queryText,
+  resultText1,
+  resultText2,
 }: OpenSearchComparisonProps) => {
   // State for selected display field
   const [displayField, setDisplayField] = useState('_id');
@@ -289,7 +295,9 @@ export const VisualComparison = ({
 
   return (
     <div className="p-4">
-      {/* Field selector dropdown */}
+      <h3 className="text-lg font-semibold mb-2">Results for query: <em>{queryText}</em></h3>
+
+        {/* Field selector dropdown */}
       <div className="mb-4">
         <label htmlFor="field-selector" className="block text-sm font-medium text-gray-700 mb-1">
           Display Field:
@@ -310,7 +318,6 @@ export const VisualComparison = ({
       
       {/* Summary section with Venn diagram style using CSS classes */}
       <div className="mb-6">
-        <h3 className="text-lg font-semibold mb-4">Summary</h3>
         <div className="venn-container">
           {/* Result 1 rectangle (left) */}
           <div className="venn-left">
@@ -334,14 +341,13 @@ export const VisualComparison = ({
 
       {/* Rank-based overlap visualization */}
       <div className="mb-6">
-        <h3 className="text-lg font-semibold mb-2">Visual Comparison</h3>
         <div className="flex justify-between mb-4">
           <div className="text-center w-1/4">
-            <h4 className="font-semibold">Result 1</h4>
+            <h4 className="font-semibold">{resultText1}</h4>
             <div className="text-sm text-gray-600">({result1.length} results)</div>
           </div>
           <div className="text-center w-1/4">
-            <h4 className="font-semibold">Result 2</h4>
+            <h4 className="font-semibold">{resultText2}</h4>
             <div className="text-sm text-gray-600">({result2.length} results)</div>
           </div>
         </div>


### PR DESCRIPTION
### Description
Fix the following issues (from the meeting with Eric and Stavros):
 * Make listing of results symmetric: right justified text, image, rank. This would avoid the whitespace next to the connecting lines
 * Fix bug in rank formatting (when selecting something other than ID, the circles of the ranks turn into different shapes)
 * Show image of product in hover pane
 * Use a Venn Diagram with circle corner rectangles to show the summary for each result
 * Replace "Visual Comparison" by Query: Gloves (e.g.)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
