### PR TITLE
Make eyeball tool resizable to improve usability

### DIFF
--- a/public/components/experiment_view/experiment_view.tsx
+++ b/public/components/experiment_view/experiment_view.tsx
@@ -19,6 +19,7 @@ import {
     EuiPageTemplate,
     EuiPanel,
     EuiText,
+    EuiResizableContainer,
   } from '@elastic/eui';
 import {
     TableListView,
@@ -31,7 +32,6 @@ import { VisualComparison, convertFromSearchResult } from '../query_compare/sear
 import {
   SearchResults,
 } from '../../types/index';
-
 
 interface ExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
@@ -224,50 +224,53 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id }) => {
       />
 
       <EuiPanel hasBorder paddingSize="l">
-        <EuiFlexGroup direction="row" gutterSize="m">
+        <EuiResizableContainer>
+          {(EuiResizablePanel, EuiResizableButton) => {
+            return (
+            <>
+              <EuiResizablePanel initialSize={50} minSize="15%">
+                {error ? (
+                  <EuiCallOut title="Error" color="danger">
+                    <p>{error}</p>
+                  </EuiCallOut>
+                ) : (
+                  <TableListView
+                    entityName="Query"
+                    entityNamePlural="Queries"
+                    tableColumns={tableColumns}
+                    findItems={findQueries}
+                    loading={loading}
+                    pagination={{
+                      initialPageSize: 10,
+                      pageSizeOptions: [5, 10, 20, 50],
+                    }}
+                    search={{
+                      box: {
+                        incremental: true,
+                        placeholder: 'Query...',
+                        schema: true,
+                      },
+                    }}
+                  />
+                )}
+              </EuiResizablePanel>
 
-          <EuiFlexItem>
-            {error ? (
-              <EuiCallOut title="Error" color="danger">
-                <p>{error}</p>
-              </EuiCallOut>
-            ) : (
-              <TableListView
-                entityName="Query"
-                entityNamePlural="Queries"
-                tableColumns={tableColumns}
-                findItems={findQueries}
-                loading={loading}
-                pagination={{
-                  initialPageSize: 10,
-                  pageSizeOptions: [5, 10, 20, 50],
-                }}
-                search={{
-                  box: {
-                    incremental: true,
-                    placeholder: 'Query...',
-                    schema: true,
-                  },
-                }}
-              />
-            )}
-          </EuiFlexItem>
+              <EuiResizableButton />
 
-
-      {(selectedQuery!=null && queryResult1 && queryResult2) && (
-        <EuiFlexItem  style={{ maxWidth: '50%' }}>
-          <VisualComparison
-            queryResult1={convertFromSearchResult(queryResult1)}
-            queryResult2={convertFromSearchResult(queryResult2)}
-            queryText={queryEntries[selectedQuery].queryText}
-            resultText1={`${searchConfigurations[0].name} result`}
-            resultText2={`${searchConfigurations[1].name} result`}
-          />
-        </EuiFlexItem>
-      )}
-
-
-        </EuiFlexGroup>
+              <EuiResizablePanel initialSize={50} minSize="30%">
+                {selectedQuery != null && queryResult1 && queryResult2 && (
+                  <VisualComparison
+                    queryResult1={convertFromSearchResult(queryResult1)}
+                    queryResult2={convertFromSearchResult(queryResult2)}
+                    queryText={queryEntries[selectedQuery].queryText}
+                    resultText1={`${searchConfigurations[0].name} result`}
+                    resultText2={`${searchConfigurations[1].name} result`}
+                  />
+                )}
+              </EuiResizablePanel>
+            </>
+          )}}
+        </EuiResizableContainer>
       </EuiPanel>
 
 

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { EuiPanel, EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent } from '@elastic/eui';
+import { EuiPanel, EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent, EuiSuperSelect, EuiFormRow } from '@elastic/eui';
 
 import './visual_comparison.scss';
 import { ItemDetailHoverPane } from './item_detail_hover_pane';
@@ -305,26 +305,24 @@ export const VisualComparison = ({
           <h3 className="text-lg font-semibold mb-2">Results for query: <em>{queryText}</em></h3>
 
           {/* Field selector dropdown */}
-          <div className="mb-4 flex items-center gap-4">
-            <label htmlFor="field-selector" className="text-sm font-medium text-gray-700">
-              Display Field:
-            </label>
-            <select
-              id="field-selector"
-              className="w-full max-w-xs px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-indigo-500 focus:border-indigo-500"
-              value={displayField}
-              onChange={(e) => setDisplayField(e.target.value)}
-            >
-              {displayFields && displayFields.length > 0 ? (
-                displayFields.map((field) => (
-                  <option key={field.value} value={field.value}>
-                    {field.label}
-                  </option>
-                ))
-              ) : (
-                <option value="">No fields available</option>
-              )}
-            </select>
+          <div className="mb-4">
+            <EuiFormRow label="Display Field:" id="fieldSelectorForm">
+              <EuiSuperSelect
+                id="field-selector"
+                options={displayFields && displayFields.length > 0 
+                  ? displayFields.map((field) => ({
+                      value: field.value,
+                      inputDisplay: field.label,
+                      dropdownDisplay: field.label,
+                    }))
+                  : [{ value: '', inputDisplay: 'No fields available', dropdownDisplay: 'No fields available' }]
+                }
+                valueOfSelected={displayField}
+                onChange={(value) => setDisplayField(value)}
+                fullWidth
+                hasDividers
+              />
+            </EuiFormRow>
           </div>
 
           {/* Summary section with Venn diagram style using CSS classes */}


### PR DESCRIPTION
### Description
Previously the eyeballing tool (experiment view) made it difficult to visualize fields other than IDs. In order to make it easier to see other fields, the panes are made resizable. See the screenshot for reference.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).

<img width="1525" alt="Screenshot 2025-04-28 at 16 27 03" src="https://github.com/user-attachments/assets/df34c5cf-9e37-41e5-863f-90bb7f9255e1" />

