### PR TITLE
support create/view experiment with evaluation experiment

### DIFF
--- a/public/components/experiment_create/configuration/configuration_action.tsx
+++ b/public/components/experiment_create/configuration/configuration_action.tsx
@@ -1,22 +1,16 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButton,
-  EuiButtonEmpty,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty } from '@elastic/eui';
 import { ConfigurationActionsProps } from './types';
 
-export const ConfigurationActions = ({
-                                       onBack,
-                                       onClose,
-                                       onNext,
-                                     }: ConfigurationActionsProps) => (
+export const ConfigurationActions = ({ onBack, onClose, onNext }: ConfigurationActionsProps) => (
   <EuiFlexGroup justifyContent="flexEnd">
     <EuiFlexItem grow={false}>
-      <EuiButtonEmpty onClick={onBack}>
-        Back to Templates
-      </EuiButtonEmpty>
+      <EuiButtonEmpty onClick={onBack}>Back to Templates</EuiButtonEmpty>
     </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiButton fill onClick={onClose}>

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -1,5 +1,9 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useState, useEffect } from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
 import { ResultListComparisonForm } from './form/result_list_comparison_form';
 import { UserBehaviorForm } from './form/user_behavior_form';
 import { LLMForm } from './form/llm_form';
@@ -26,16 +30,12 @@ const getInitialFormData = (templateType: string): ConfigurationFormData => {
     case 'User Behavior':
       return {
         ...baseData,
-        startDate: '',
-        endDate: '',
-        collectSignal: '',
-        scoreThreshold: '',
+        judgmentId: '',
       };
     case 'LLM':
       return {
         ...baseData,
         modelId: '',
-        scoreThreshold: '',
       };
     default:
       return (baseData as unknown) as
@@ -67,10 +67,6 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
     }));
   };
 
-  const handleSave = () => {
-    onSave(formData);
-  };
-
   const renderForm = () => {
     switch (templateType) {
       case 'Result List Comparison':
@@ -83,22 +79,14 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
         );
       case 'User Behavior':
         return (
-          <UserBehaviorForm formData={formData as UserBehaviorFormData} onChange={handleChange} />
+          <UserBehaviorForm
+            formData={formData as UserBehaviorFormData}
+            onChange={handleChange}
+            http={http}
+          />
         );
       case 'LLM':
-        return (
-          <>
-            <LLMForm formData={formData as LLMFormData} onChange={handleChange} />
-
-            <EuiFlexGroup justifyContent="flexEnd">
-              <EuiFlexItem grow={false}>
-                <EuiFormRow hasEmptyLabelSpace>
-                  <EuiButton onClick={handleSave}>Save Judgement</EuiButton>
-                </EuiFormRow>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </>
-        );
+        return <LLMForm formData={formData as LLMFormData} onChange={handleChange} http={http} />;
       default:
         return null;
     }

--- a/public/components/experiment_create/configuration/form/llm_form.tsx
+++ b/public/components/experiment_create/configuration/form/llm_form.tsx
@@ -1,51 +1,105 @@
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldText, EuiComboBox } from '@elastic/eui';
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiFieldText,
+  EuiComboBox,
+  EuiFieldNumber,
+} from '@elastic/eui';
 import { LLMFormData, QuerySetOption } from '../types';
-import { mockupQuerySetOptions } from '../../../resource_management_home/mockup_data';
+import { ServiceEndpoints } from '../../../../../common';
+import { CoreStart } from '../../../../../src/core/public';
 
 interface LLMFormProps {
   formData: LLMFormData;
   onChange: (field: keyof LLMFormData, value: any) => void;
+  http: CoreStart['http'];
 }
 
-export const LLMForm = ({ formData, onChange }: LLMFormProps) => {
+export const LLMForm = ({ formData, onChange, http }: LLMFormProps) => {
+  const [querySetOptions, setQuerySetOptions] = useState<QuerySetOption[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [k, setK] = useState<number>(formData.k || 10);
+
+  useEffect(() => {
+    const fetchQuerySets = async () => {
+      try {
+        const data = await http.get(ServiceEndpoints.QuerySets);
+        const options = data.hits.hits.map((qs: any) => ({
+          label: qs._source.name,
+          value: qs._source.id,
+        }));
+        setQuerySetOptions(options);
+      } catch (error) {
+        console.error('Failed to fetch query sets', error);
+        setQuerySetOptions([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchQuerySets();
+  }, [http]);
+
   const handleQuerySetsChange = (selectedOptions: QuerySetOption[]) => {
     onChange('querySets', selectedOptions || []);
   };
 
+  const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    setK(value);
+    onChange('k', value);
+  };
+
   return (
-    <>
-      <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
-        <EuiFlexItem grow={4}>
-          <EuiFormRow label="Query Sets">
-            <EuiComboBox
-              placeholder="Select query sets"
-              options={mockupQuerySetOptions}
-              selectedOptions={formData.querySets}
-              onChange={handleQuerySetsChange}
-              isClearable={true}
-              isInvalid={formData.querySets.length === 0}
-              multi={true}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow label="Model Id">
-            <EuiFieldText
-              value={formData.modelId}
-              onChange={(e) => onChange('modelId', e.target.value)}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow label="Score Threshold">
-            <EuiFieldText
-              value={formData.scoreThreshold}
-              onChange={(e) => onChange('scoreThreshold', e.target.value)}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup gutterSize="m" direction="column" style={{ maxWidth: 600 }}>
+      <EuiFlexItem>
+        <EuiFormRow label="Query Sets">
+          <EuiComboBox
+            placeholder={isLoading ? 'Loading...' : 'Select query sets'}
+            options={querySetOptions}
+            selectedOptions={formData.querySets}
+            onChange={handleQuerySetsChange}
+            isClearable
+            isInvalid={formData.querySets.length === 0}
+            isLoading={isLoading}
+            async
+            fullWidth
+            multi
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem>
+        <EuiFlexGroup gutterSize="m">
+          <EuiFlexItem>
+            <EuiFormRow label="K Value">
+              <EuiFieldNumber
+                placeholder="Enter k value"
+                value={k}
+                onChange={handleKChange}
+                min={1}
+                fullWidth
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+          <EuiFlexItem>
+            <EuiFormRow label="Model ID">
+              <EuiFieldText
+                placeholder="Enter model ID"
+                value={formData.modelId}
+                onChange={(e) => onChange('modelId', e.target.value)}
+                fullWidth
+              />
+            </EuiFormRow>
+          </EuiFlexItem>
+        </EuiFlexGroup>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
+++ b/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useEffect, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiComboBox, EuiFieldNumber } from '@elastic/eui';
 import { ResultListComparisonFormData, QuerySetOption } from '../types';
@@ -29,7 +34,6 @@ export const ResultListComparisonForm = ({
         }));
         setQuerySetOptions(options);
       } catch (error) {
-        console.error('Failed to fetch query sets', error);
         setQuerySetOptions([]);
       } finally {
         setIsLoading(false);

--- a/public/components/experiment_create/configuration/form/user_behavior_form.tsx
+++ b/public/components/experiment_create/configuration/form/user_behavior_form.tsx
@@ -1,68 +1,100 @@
-import React from 'react';
-import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldText, EuiComboBox } from '@elastic/eui';
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from "react";
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiFormRow,
+  EuiFieldText,
+  EuiComboBox,
+  EuiFieldNumber,
+} from '@elastic/eui';
 import { QuerySetOption, UserBehaviorFormData } from '../types';
-import { mockupQuerySetOptions } from '../../../resource_management_home/mockup_data';
+import { CoreStart } from '../../../../../src/core/public';
+import { ServiceEndpoints } from '../../../../../common';
 
 interface UserBehaviorFormProps {
   formData: UserBehaviorFormData;
   onChange: (field: keyof UserBehaviorFormData, value: any) => void;
+  http: CoreStart['http'];
 }
 
-export const UserBehaviorForm = ({ formData, onChange }: UserBehaviorFormProps) => {
+export const UserBehaviorForm = ({ formData, onChange, http }: UserBehaviorFormProps) => {
+  const [querySetOptions, setQuerySetOptions] = useState<QuerySetOption[]>([]);
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [k, setK] = useState<number>(10);
+
+  useEffect(() => {
+    const fetchQuerySets = async () => {
+      try {
+        const data = await http.get(ServiceEndpoints.QuerySets);
+        const options = data.hits.hits.map((qs: any) => ({
+          label: qs._source.name,
+          value: qs._source.id,
+        }));
+        setQuerySetOptions(options);
+      } catch (error) {
+        setQuerySetOptions([]);
+      } finally {
+        setIsLoading(false);
+      }
+    };
+
+    fetchQuerySets();
+  }, [http]);
+
   const handleQuerySetsChange = (selectedOptions: QuerySetOption[]) => {
     onChange('querySets', selectedOptions || []);
   };
 
+  const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = parseInt(e.target.value, 10);
+    setK(value);
+    onChange('k', value);
+  };
+
   return (
-    <>
-      <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
-        <EuiFlexItem grow={4}>
-          <EuiFormRow label="Query Sets">
-            <EuiComboBox
-              placeholder="Select query sets"
-              options={mockupQuerySetOptions}
-              selectedOptions={formData.querySets}
-              onChange={handleQuerySetsChange}
-              isClearable={true}
-              isInvalid={formData.querySets.length === 0}
-              multi={true}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow label="Start Date">
-            <EuiFieldText
-              value={formData.startDate}
-              onChange={(e) => onChange('startDate', e.target.value)}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow label="End Date">
-            <EuiFieldText
-              value={formData.endDate}
-              onChange={(e) => onChange('endDate', e.target.value)}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow label="Collect Model">
-            <EuiFieldText
-              placeholder="CLICK_MODEL"
-              value={formData.collectSignal}
-              onChange={(e) => onChange('collectSignal', e.target.value)}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-        <EuiFlexItem grow={2}>
-          <EuiFormRow label="Score Threshold">
-            <EuiFieldText
-              value={formData.scoreThreshold}
-              onChange={(e) => onChange('scoreThreshold', e.target.value)}
-            />
-          </EuiFormRow>
-        </EuiFlexItem>
-      </EuiFlexGroup>
-    </>
+    <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
+      <EuiFlexItem grow={4}>
+        <EuiFormRow label="Query Sets">
+          <EuiComboBox
+            placeholder={isLoading ? 'Loading...' : 'Select query sets'}
+            options={querySetOptions}
+            selectedOptions={formData.querySets}
+            onChange={handleQuerySetsChange}
+            isClearable
+            isInvalid={formData.querySets.length === 0}
+            isLoading={isLoading}
+            async
+            fullWidth
+            multi
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={1}>
+        <EuiFormRow label="K Value">
+          <EuiFieldNumber
+            placeholder="Enter k value"
+            value={k}
+            onChange={handleKChange}
+            min={1}
+            fullWidth
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+      <EuiFlexItem grow={3}>
+        <EuiFormRow label="Judgment ID">
+          <EuiFieldText
+            placeholder="Enter UBI judgment ID"
+            value={formData.judgmentId}
+            onChange={(e) => onChange('judgmentId', e.target.value)}
+            fullWidth
+          />
+        </EuiFormRow>
+      </EuiFlexItem>
+    </EuiFlexGroup>
   );
 };

--- a/public/components/experiment_create/configuration/search_configuration_form.tsx
+++ b/public/components/experiment_create/configuration/search_configuration_form.tsx
@@ -1,3 +1,8 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useEffect, useState } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiComboBox } from '@elastic/eui';
 import { SearchConfigOption, SearchConfigFromData } from './types';
@@ -18,13 +23,12 @@ export const SearchConfigForm = ({ formData, onChange, http }: SearchConfigFormP
     const fetchSearchConfigurations = async () => {
       try {
         const data = await http.get(ServiceEndpoints.SearchConfigurations);
-        const options = data.hits.hits.map((search_config: any) => ({
-          label: search_config._source.name,
-          value: search_config._source.id,
+        const options = data.hits.hits.map((searchConfig: any) => ({
+          label: searchConfig._source.name,
+          value: searchConfig._source.id,
         }));
         setSearchConfigOptions(options);
       } catch (error) {
-        console.error('Failed to fetch search configurations', error);
         setSearchConfigOptions([]);
       } finally {
         setIsLoadingConfigs(false);

--- a/public/components/experiment_create/configuration/template_configuration.tsx
+++ b/public/components/experiment_create/configuration/template_configuration.tsx
@@ -1,10 +1,20 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useState } from 'react';
 
 import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
 import { withRouter } from 'react-router-dom';
 import { ConfigurationForm } from './configuration_form';
 import { ConfigurationActions } from './configuration_action';
-import { TemplateConfigurationProps, ConfigurationFormData, SearchConfigFromData } from './types';
+import {
+  TemplateConfigurationProps,
+  ConfigurationFormData,
+  SearchConfigFromData,
+  ExperimentType,
+} from './types';
 import { SearchConfigForm } from './search_configuration_form';
 import { ServiceEndpoints } from '../../../../common';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
@@ -42,7 +52,71 @@ export const TemplateConfiguration = ({
     services: { http, notifications },
   } = useOpenSearchDashboards();
 
+  const getExperimentType = (templateType: string): ExperimentType => {
+    switch (templateType) {
+      case 'Result List Comparison':
+        return ExperimentType.PAIRWISE_COMPARISON;
+      case 'LLM':
+        return ExperimentType.LLM_EVALUATION;
+      case 'User Behavior':
+        return ExperimentType.UBI_EVALUATION;
+      default:
+        throw new Error(`Unsupported template type: ${templateType}`);
+    }
+  };
+
+  const validateExperimentData = (
+    configFormData: any,
+    searchConfigData: any,
+    templateType: string
+  ) => {
+    const errors: string[] = [];
+
+    if (!configFormData?.k || configFormData.k <= 0) {
+      errors.push('K value is required and must be greater than 0');
+    }
+    if (!configFormData?.querySets || configFormData.querySets.length === 0) {
+      errors.push('Query set is required');
+    }
+    if (!searchConfigData?.searchConfigs || searchConfigData.searchConfigs.length === 0) {
+      errors.push('At least one search configuration is required');
+    }
+
+    // Template specific validations
+    if (
+      templateType === 'LLM' &&
+      (!configFormData?.modelId || configFormData.modelId.trim() === '')
+    ) {
+      errors.push('Model ID is required for LLM experiments');
+    }
+    if (
+      templateType === 'User Behavior' &&
+      (!configFormData?.judgmentId || configFormData.judgmentId.trim() === '')
+    ) {
+      errors.push('Judgment ID is required for User Behavior experiments');
+    }
+
+    return errors;
+  };
+
   const handleNext = async () => {
+    const validationErrors = validateExperimentData(configFormData, searchConfigData, templateType);
+
+    if (validationErrors.length > 0) {
+      // Show all validation errors in a single toast
+      notifications.toasts.addDanger({
+        title: 'Validation Error',
+        text: (
+          <ul>
+            {validationErrors.map((error, index) => (
+              <li key={index}>{error}</li>
+            ))}
+          </ul>
+        ),
+      });
+      return;
+    }
+
     if (configFormData && searchConfigData.searchConfigs.length > 0) {
       const combinedData = {
         ...configFormData,
@@ -50,17 +124,29 @@ export const TemplateConfiguration = ({
       };
       try {
         setIsCreating(true);
+        const requestBody: any = {
+          k: combinedData.k,
+          querySetId: combinedData.querySets[0].value,
+          searchConfigurationList: combinedData.searchConfigs.map((o) => o.value),
+          type: getExperimentType(templateType),
+        };
+        // Add modelId if the template type is LLM
+        if (templateType === 'LLM' && 'modelId' in configFormData) {
+          requestBody.modelId = configFormData.modelId;
+        }
+        // Add judgmentId if the template type is User Behavior
+        if (templateType === 'User Behavior' && 'judgmentId' in configFormData) {
+          requestBody.judgmentId = configFormData.judgmentId;
+        }
         const response = await http.post(ServiceEndpoints.Experiments, {
-          body: JSON.stringify({
-            k: combinedData.k,
-            querySetId: combinedData.querySets[0].value,
-            searchConfigurationList: combinedData.searchConfigs.map((o) => o.value),
-          }),
+          body: JSON.stringify(requestBody),
         });
 
         if (response.experiment_id) {
           setExperimentId(response.experiment_id);
-          notifications.toasts.addSuccess(`Experiment ${response.experiment_id} created successfully`);
+          notifications.toasts.addSuccess(
+            `Experiment ${response.experiment_id} created successfully`
+          );
           history.push(`/experiment/`);
         } else {
           throw new Error('No experiment ID received');

--- a/public/components/experiment_create/configuration/types.tsx
+++ b/public/components/experiment_create/configuration/types.tsx
@@ -1,3 +1,7 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
 import { RouteComponentProps } from 'react-router-dom';
 
 export interface TemplateConfigurationProps extends RouteComponentProps {
@@ -28,15 +32,11 @@ export interface IndexOption {
 export interface ResultListComparisonFormData extends BaseFormData {}
 
 export interface UserBehaviorFormData extends BaseFormData {
-  startDate: string;
-  endDate: string;
-  collectSignal: string;
-  scoreThreshold: string;
+  judgmentId: string;
 }
 
 export interface LLMFormData extends BaseFormData {
   modelId: string;
-  scoreThreshold: string;
 }
 
 export type ConfigurationFormData =
@@ -58,4 +58,10 @@ export interface QuerySetOption {
 export interface SearchConfigOption {
   label: string;
   value: string;
+}
+
+export enum ExperimentType {
+  PAIRWISE_COMPARISON = 'PAIRWISE_COMPARISON',
+  LLM_EVALUATION = 'LLM_EVALUATION',
+  UBI_EVALUATION = 'UBI_EVALUATION',
 }

--- a/public/components/experiment_create/evaluation/evaluation_results.tsx
+++ b/public/components/experiment_create/evaluation/evaluation_results.tsx
@@ -1,0 +1,216 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useEffect, useState } from 'react';
+import {
+  EuiPanel,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiSpacer,
+  EuiButtonEmpty,
+  EuiHorizontalRule,
+  EuiLoadingSpinner,
+  EuiText,
+  EuiHealth,
+  EuiCallOut,
+  EuiBasicTable,
+} from '@elastic/eui';
+import { ServiceEndpoints } from '../../../../common';
+import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+
+interface EvaluationResultsProps {
+  templateType: string;
+  experimentId: string;
+  onBack: () => void;
+}
+
+export const EvaluationResults = ({
+  templateType,
+  experimentId,
+  onBack,
+}: EvaluationResultsProps) => {
+  const [isLoading, setIsLoading] = useState<boolean>(true);
+  const [error, setError] = useState<string | null>(null);
+  const [experimentResults, setExperimentResults] = useState<any>(null);
+
+  const {
+    services: { http, notifications },
+  } = useOpenSearchDashboards();
+
+  useEffect(() => {
+    if (experimentId) {
+      fetchExperimentResults();
+    }
+  }, [experimentId]);
+
+  const fetchExperimentResults = async () => {
+    try {
+      setIsLoading(true);
+      setError(null);
+
+      const response = await http.get(`${ServiceEndpoints.Experiments}/${experimentId}`);
+      const experiment = response?.hits?.hits?.[0]?._source;
+
+      if (!experiment) {
+        throw new Error('No experiment results found');
+      }
+
+      setExperimentResults(experiment);
+    } catch (err) {
+      setError('Failed to load experiment results');
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  const renderMetricsTable = (queryText: string, metrics: any) => {
+    if (!metrics || (!metrics.pairwiseComparison && !metrics.evaluation)) return null;
+
+    if (metrics.pairwiseComparison) {
+      const columns = [
+        {
+          field: 'metric',
+          name: 'Metric',
+          sortable: true,
+        },
+        {
+          field: 'value',
+          name: 'Value',
+          sortable: true,
+          render: (value: number) => Number(value).toFixed(2),
+        },
+      ];
+      const items = Object.entries(metrics.pairwiseComparison).map(([metric, value]) => ({
+        metric,
+        value,
+      }));
+      return <EuiBasicTable items={items} columns={columns} compressed />;
+    } else if (metrics.evaluation) {
+      const columns = [
+        {
+          field: 'metric',
+          name: 'Metric',
+          width: '200px',
+        },
+        ...experimentResults.searchConfigurationList.map((configId: string, index: number) => ({
+          field: `config_${index}`,
+          name: `Configuration ${index + 1}`,
+          render: (value: number) => (value !== undefined ? Number(value).toFixed(4) : '-'),
+        })),
+      ];
+
+      const metricOrder = ['precision@5', 'precision@10', 'ndcg', 'MAP'];
+      const items = metricOrder.map((metric) => ({
+        metric,
+        ...experimentResults.searchConfigurationList.reduce(
+          (acc: any, configId: string, index: number) => {
+            acc[`config_${index}`] = metrics.evaluation[index]?.[metric];
+            return acc;
+          },
+          {}
+        ),
+      }));
+
+      return (
+        <EuiPanel paddingSize="s">
+          <EuiBasicTable items={items} columns={columns} compressed />
+        </EuiPanel>
+      );
+    }
+    return null;
+  };
+
+  const renderQueryResults = () => {
+    if (!experimentResults?.results?.metrics) return null;
+
+    return Object.entries(experimentResults.results.metrics).map(
+      ([queryText, metrics]: [string, any]) => {
+        const hasError =
+          metrics['0']?.[0]?.includes('Error') || metrics['1']?.[0]?.includes('Error');
+
+        return (
+          <EuiFlexItem key={queryText}>
+            <EuiPanel paddingSize="m">
+              <EuiFlexGroup alignItems="center" gutterSize="s">
+                <EuiFlexItem grow={false}>
+                  <EuiHealth color={hasError ? 'danger' : 'success'}>Query: {queryText}</EuiHealth>
+                </EuiFlexItem>
+              </EuiFlexGroup>
+              <EuiSpacer size="s" />
+              {hasError ? (
+                <EuiText color="danger" size="s">
+                  {metrics['0'][0]}
+                </EuiText>
+              ) : (
+                renderMetricsTable(queryText, metrics)
+              )}
+            </EuiPanel>
+          </EuiFlexItem>
+        );
+      }
+    );
+  };
+
+  if (isLoading) {
+    return (
+      <EuiFlexGroup justifyContent="center" alignItems="center" style={{ minHeight: '200px' }}>
+        <EuiFlexItem grow={false}>
+          <EuiLoadingSpinner size="xl" />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+
+  if (error) {
+    return (
+      <EuiCallOut title="Error loading results" color="danger" iconType="alealert">
+        <p>{error}</p>
+        <EuiButtonEmpty onClick={onBack}>Back to configuration</EuiButtonEmpty>
+      </EuiCallOut>
+    );
+  }
+
+  return (
+    <div>
+      <EuiFlexGroup alignItems="center">
+        <EuiFlexItem grow={false}>
+          <EuiButtonEmpty iconType="arrowLeft" onClick={onBack} size="s">
+            Back to configuration
+          </EuiButtonEmpty>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="l" />
+
+      <EuiFlexGroup direction="column">
+        {experimentResults && (
+          <>
+            <EuiFlexItem>
+              <EuiText>
+                <h3>Experiment Details</h3>
+              </EuiText>
+              <EuiSpacer size="s" />
+              <EuiText size="s">
+                <p>Query Set ID: {experimentResults.querySetId}</p>
+                <p>K: {experimentResults.k}</p>
+                <p>Configurations: {experimentResults.searchConfigurationList.join(', ')}</p>
+              </EuiText>
+            </EuiFlexItem>
+
+            <EuiHorizontalRule />
+
+            <EuiFlexItem>
+              <EuiText>
+                <h3>Metrics</h3>
+              </EuiText>
+              <EuiSpacer size="s" />
+              {renderQueryResults()}
+            </EuiFlexItem>
+          </>
+        )}
+      </EuiFlexGroup>
+    </div>
+  );
+};

--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -13,16 +13,16 @@ import {
   EuiPageHeader,
   EuiButtonIcon,
 } from '@elastic/eui';
+import { RouteComponentProps, withRouter } from 'react-router-dom';
+import moment from 'moment';
 import {
   reactRouterNavigate,
   TableListView,
 } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../src/core/public';
-import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
 import { useConfig } from '../../contexts/date_format_context';
-import moment from 'moment';
 
 interface ExperimentListingProps extends RouteComponentProps {
   http: CoreStart['http'];
@@ -44,7 +44,6 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
       const response = await http.delete(
         `${ServiceEndpoints.Experiments}/${experimentToDelete.id}`
       );
-      console.log('Delete successful:', response);
 
       // Close modal and clear state
       setShowDeleteModal(false);
@@ -86,13 +85,23 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
       ),
     },
     {
-      field: 'searchConfigurationList',
+      field: 'results',
       name: 'Evaluation Type',
       dataType: 'string',
       sortable: true,
-      render: (searchConfigurationList: string[]) => {
-        const evaluationType =
-          searchConfigurationList.length === 2 ? 'Result List Comparison' : 'Quality Metrics';
+      render: (results: any) => {
+        if (!results || !results.metrics) return <EuiText size="s">-</EuiText>;
+
+        // Get the first query's metrics to determine the type
+        const firstQueryKey = results.queryTexts[0];
+        const firstQueryMetrics = results.metrics[firstQueryKey];
+
+        const evaluationType = firstQueryMetrics.pairwiseComparison
+          ? 'Result List Comparison'
+          : firstQueryMetrics.evaluation
+          ? 'Quality Metrics'
+          : '-';
+
         return <EuiText size="s">{evaluationType}</EuiText>;
       },
     },

--- a/public/components/experiment_view/evaluation_metrics_summary.tsx
+++ b/public/components/experiment_view/evaluation_metrics_summary.tsx
@@ -1,0 +1,74 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiStat,
+  EuiTitle,
+  EuiHorizontalRule,
+} from '@elastic/eui';
+import React from 'react';
+
+interface MetricsSummaryPanelProps {
+  metrics: {
+    'precision@5'?: number;
+    'precision@10'?: number;
+    MAP?: number;
+    ndcg?: number;
+  };
+  configIndex: string;
+}
+
+export const MetricsSummaryPanel: React.FC<MetricsSummaryPanelProps> = ({ metrics, configIndex }) => {
+  const formatValue = (value: number | undefined) => {
+    if (value === undefined) return '-';
+    return (value * 100).toFixed(1) + '%';
+  };
+
+  return (
+    <EuiPanel paddingSize="l">
+      <EuiTitle size="s">
+        <h3>Metrics Summary for Search Configuration {configIndex}</h3>
+      </EuiTitle>
+      <EuiHorizontalRule margin="m" />
+      <EuiFlexGroup>
+        <EuiFlexItem grow={2}>
+          <EuiStat
+            title={formatValue(metrics['precision@5'])}
+            description="Precision@5"
+            titleColor={metrics['precision@5'] < 0.9 ? 'danger' : 'secondary'}
+            titleSize="l"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <EuiStat
+            title={formatValue(metrics['precision@10'])}
+            description="Precision@10"
+            titleColor={metrics['precision@10'] < 0.9 ? 'danger' : 'success'}
+            titleSize="l"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <EuiStat
+            title={formatValue(metrics.ndcg)}
+            description="NDCG"
+            titleColor={metrics.ndcg < 0.9 ? 'danger' : 'success'}
+            titleSize="l"
+          />
+        </EuiFlexItem>
+        <EuiFlexItem grow={2}>
+          <EuiStat
+            title={formatValue(metrics.MAP)}
+            description="MAP"
+            titleColor={metrics.MAP < 0.9 ? 'danger' : 'success'}
+            titleSize="l"
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </EuiPanel>
+  );
+};

--- a/public/components/experiment_view/evaluation_metrics_table.tsx
+++ b/public/components/experiment_view/evaluation_metrics_table.tsx
@@ -1,0 +1,89 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import {
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPanel,
+  EuiText,
+  EuiSpacer,
+  EuiSelect,
+  EuiBasicTable,
+} from '@elastic/eui';
+import React, { useState } from 'react';
+import { MetricsSummaryPanel } from './evaluation_metrics_summary';
+interface EvaluationMetricsTableProps {
+  queryText: string;
+  metrics: any;
+  judgments: any;
+}
+
+export const EvaluationMetricsTable: React.FC<EvaluationMetricsTableProps> = ({
+  queryText,
+  metrics,
+  judgments,
+}) => {
+  const [selectedConfigIndex, setSelectedConfigIndex] = useState('0');
+
+  const columns = [
+    {
+      field: 'documentId',
+      name: 'Document ID',
+      sortable: true,
+    },
+    {
+      field: 'judgmentScore',
+      name: 'Judgment Score',
+      sortable: true,
+      render: (score: number) => score?.toFixed(2) || '-',
+    },
+  ];
+
+  const getItems = () => {
+    const configResults = metrics[selectedConfigIndex] || [];
+    return configResults.map((docId: string) => ({
+      documentId: docId,
+      judgmentScore: judgments[docId] || 0,
+    }));
+  };
+
+  const evaluationMetrics = metrics.evaluation?.[selectedConfigIndex] || {};
+
+  return (
+    <EuiPanel hasBorder paddingSize="m">
+      <EuiText>
+        <h3>Evaluation Metrics for %SearchText%: {queryText}</h3>
+      </EuiText>
+
+      <EuiSpacer size="m" />
+
+      <EuiFlexGroup>
+        <EuiFlexItem grow={false}>
+          <EuiSelect
+            options={Object.keys(metrics)
+              .filter((k) => k !== 'evaluation' && k !== 'judgments')
+              .map((idx) => ({
+                value: idx,
+                text: `Configuration ${idx}`,
+              }))}
+            value={selectedConfigIndex}
+            onChange={(e) => setSelectedConfigIndex(e.target.value)}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+
+      <EuiSpacer size="m" />
+
+      <MetricsSummaryPanel
+        metrics={evaluationMetrics}
+        configIndex={selectedConfigIndex}
+      />
+
+      <EuiSpacer size="l" />
+
+      <EuiBasicTable items={getItems()} columns={columns} />
+    </EuiPanel>
+  );
+};

--- a/public/components/experiment_view/experiment_view.tsx
+++ b/public/components/experiment_view/experiment_view.tsx
@@ -4,29 +4,33 @@
  */
 
 import {
-    EuiButtonEmpty,
-    EuiCallOut,
-    EuiPageHeader,
-    EuiPageTemplate,
-    EuiPanel,
-    EuiResizableContainer,
-    EuiDescriptionList,
-    EuiDescriptionListTitle,
-    EuiDescriptionListDescription,
-    EuiSpacer,
-  } from '@elastic/eui';
-import {
-    TableListView,
-    reactRouterNavigate,
-} from '../../../../../src/plugins/opensearch_dashboards_react/public';  
+  EuiButtonEmpty,
+  EuiCallOut,
+  EuiFlexGroup,
+  EuiFlexItem,
+  EuiPageHeader,
+  EuiPageTemplate,
+  EuiPanel,
+  EuiSpacer,
+  EuiResizableContainer,
+  EuiDescriptionList,
+  EuiDescriptionListTitle,
+  EuiDescriptionListDescription,
+} from '@elastic/eui';
 import React, { useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
+import {
+  reactRouterNavigate,
+  TableListView,
+} from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../common';
-import { VisualComparison, convertFromSearchResult } from '../query_compare/search_result/visual_comparison/visual_comparison';
 import {
-  SearchResults,
-} from '../../types/index';
+  VisualComparison,
+  convertFromSearchResult,
+} from '../query_compare/search_result/visual_comparison/visual_comparison';
+import { SearchResults } from '../../types/index';
+import { EvaluationMetricsTable } from './evaluation_metrics_table';
 
 interface ExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
@@ -41,17 +45,20 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
   const [selectedQuery, setSelectedQuery] = useState<number | null>(null);
   const [queryResult1, setQueryResult1] = useState<SearchResults | null>(null);
   const [queryResult2, setQueryResult2] = useState<SearchResults | null>(null);
-  
 
   // Detailed experiment details
   const [queryEntries, setQueryEntries] = useState<any[]>([]);
   const [tableColumns, setTableColumns] = useState<any[]>([]);
 
+  const [queries, setQueries] = useState<any[]>([]);
+
   const sanitizeResponse = (response) => response?.hits?.hits?.[0]?._source || undefined;
 
   const loadSearchConfigurations = async (searchConfigurationIds: string[]) => {
     const promises = searchConfigurationIds.map(async (id) => {
-      return await http.get(ServiceEndpoints.SearchConfigurations + "/" + id).then(sanitizeResponse);
+      return await http
+        .get(ServiceEndpoints.SearchConfigurations + '/' + id)
+        .then(sanitizeResponse);
     });
     return Promise.all(promises);
   };
@@ -60,11 +67,23 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
     const fetchExperiment = async () => {
       try {
         setLoading(true);
-        const _experiment = await http.get(ServiceEndpoints.Experiments + "/" + id).then(sanitizeResponse);
-        const _searchConfigurations = _experiment ? await loadSearchConfigurations(_experiment.searchConfigurationList) : [];
-        const _querySet = _experiment ? await http.get(ServiceEndpoints.QuerySets + "/" + _experiment.querySetId).then(sanitizeResponse) : null;
+        const _experiment = await http
+          .get(ServiceEndpoints.Experiments + '/' + id)
+          .then(sanitizeResponse);
+        const _searchConfigurations = _experiment
+          ? await loadSearchConfigurations(_experiment.searchConfigurationList)
+          : [];
+        const _querySet = _experiment
+          ? await http
+              .get(ServiceEndpoints.QuerySets + '/' + _experiment.querySetId)
+              .then(sanitizeResponse)
+          : null;
 
-        if (_experiment && _searchConfigurations.length >= 2 && _searchConfigurations.every(Boolean)) {
+        if (
+          _experiment &&
+          _searchConfigurations.length >= 2 &&
+          _searchConfigurations.every(Boolean)
+        ) {
           setExperiment(_experiment);
           setSearchConfigurations(_searchConfigurations);
           setQuerySet(_querySet);
@@ -82,73 +101,109 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
     fetchExperiment();
   }, [http, id]);
 
-  function extractMetricNames(obj: any): string[] {
-    const metrics = obj.results?.metrics;
+  function extractMetricNames(
+    obj: any
+  ): { pairwiseMetrics: string[]; evaluationMetrics: string[] } {
+    const metrics = obj?.results?.metrics;
     if (metrics) {
-      const key0 = Object.keys(metrics)[0]
-      const queryMetrics = metrics[key0]
-      if (queryMetrics.pairwiseComparison) {
-        return Object.keys(queryMetrics.pairwiseComparison)
-      }
+      const key0 = Object.keys(metrics)[0];
+      const queryMetrics = metrics[key0];
+      return {
+        pairwiseMetrics: queryMetrics.pairwiseComparison
+          ? Object.keys(queryMetrics.pairwiseComparison)
+          : [],
+        evaluationMetrics: queryMetrics.evaluation ? Object.keys(queryMetrics.evaluation) : [],
+      };
     }
-    return [];
+    return { pairwiseMetrics: [], evaluationMetrics: [] };
   }
 
   useEffect(() => {
     if (experiment) {
-      const metricNames = extractMetricNames(experiment)
-      let _metrics = {}
-      let _metricMeans = {}
-      let _queryEntries = experiment.results.queryTexts.map(t => ({queryText: t, queryResults: {}, metrics: {}}))
-      metricNames.forEach(metricName => {
-        const vals = experiment.results.queryTexts.map(q => experiment.results.metrics[q].pairwiseComparison[metricName])
-        vals.forEach((val, i) => {
-          _queryEntries[i].metrics[metricName] = val
-        })
-        _metricMeans[metricName] = vals.reduce((a, b) => a + b, 0) / vals.length
-      })
-      // Store query results
-      experiment.results.queryTexts.forEach((queryText, i) => {
-        ["0", "1"].forEach(queryName => {
-          const queryResults = experiment.results.metrics[queryText][queryName]
-          _queryEntries[i].queryResults[queryName] = queryResults
-          _queryEntries[i]["index"] = i
-        })
-      })
-
-      const cheatColNames = {
-        rbo90: "RBO@" + experiment.k,
-        jaccard: "Jaccard@" + experiment.k,
-      }
-
-      let columns = [
+      setQueries(experiment.results.queryTexts);
+      const _metricMeans = {};
+      let _queryEntries = [];
+      const columns = [
         {
-            field: 'queryText',
-            name: 'Query',
-            dataType: 'string',
-            sortable: true,
-            render: (
-                name: string,
-                queryEntry: {
-                    index: number;
-                },
-            ) => (
-                <EuiButtonEmpty
-                    size="xs"
-                    onClick={() => setSelectedQuery(queryEntry.index)}
-                    title={name}
-                >
-                    {name}
-                </EuiButtonEmpty>
-              ),
-            
+          field: 'queryText',
+          name: 'Query',
+          dataType: 'string',
+          sortable: true,
+          render: (name: string, queryEntry: { index: number }) => (
+            <EuiButtonEmpty size="xs" onClick={() => setSelectedQuery(queryEntry.index)}>
+              {name}
+            </EuiButtonEmpty>
+          ),
         },
-      ]
-      Object.keys(_metricMeans).forEach(metricName => {
-        if (cheatColNames[metricName]) {
+      ];
+
+      const { pairwiseMetrics, evaluationMetrics } = extractMetricNames(experiment);
+
+      if (pairwiseMetrics.length > 0) {
+        // Process pairwise comparison metrics
+        _queryEntries = experiment.results.queryTexts.map((t, index) => ({
+          queryText: t,
+          queryResults: {},
+          metrics: {},
+          index,
+        }));
+
+        pairwiseMetrics.forEach((metricName) => {
+          const vals = experiment.results.queryTexts.map(
+            (q) => experiment.results.metrics[q].pairwiseComparison[metricName]
+          );
+          vals.forEach((val, i) => {
+            _queryEntries[i].metrics[metricName] = val;
+          });
+          _metricMeans[metricName] = vals.reduce((a, b) => a + b, 0) / vals.length;
+        });
+
+        // Store query results
+        experiment.results.queryTexts.forEach((queryText, i) => {
+          ['0', '1'].forEach((queryName) => {
+            const queryResults = experiment.results.metrics[queryText][queryName];
+            _queryEntries[i].queryResults[queryName] = queryResults;
+          });
+        });
+
+        const cheatColNames = {
+          rbo90: 'RBO@' + experiment.k,
+          jaccard: 'Jaccard@' + experiment.k,
+        };
+        Object.keys(_metricMeans).forEach((metricName) => {
+          if (cheatColNames[metricName]) {
+            columns.push({
+              field: 'metrics.' + metricName,
+              name: cheatColNames[metricName],
+              dataType: 'number',
+              sortable: true,
+              render: (value) => {
+                if (value !== undefined && value !== null) {
+                  return new Intl.NumberFormat(undefined, {
+                    minimumFractionDigits: 2,
+                    maximumFractionDigits: 2,
+                  }).format(value);
+                }
+                return '-';
+              },
+            });
+          }
+        });
+      } else if (evaluationMetrics.length > 0) {
+        // Process evaluation metrics
+        _queryEntries = experiment.results.queryTexts.map((t, index) => ({
+          queryText: t,
+          queryResults: {},
+          metrics: {},
+          evaluation: experiment.results.metrics[t].evaluation || {},
+          index,
+        }));
+
+        const cheatColNames = ['precision@5', 'precision@10', 'ndcg', 'MAP'];
+        cheatColNames.forEach((metric) => {
           columns.push({
-            field: 'metrics.' + metricName,
-            name: cheatColNames[metricName],
+            field: `evaluation.0.${metric}`,
+            name: `${metric} (Config 0)`,
             dataType: 'number',
             sortable: true,
             render: (value) => {
@@ -156,64 +211,91 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
                 return new Intl.NumberFormat(undefined, {
                   minimumFractionDigits: 2,
                   maximumFractionDigits: 2,
-                }).format(value);
+                }).format(Number(value));
               }
               return '-';
-            }
-          })
-        }
-      })
+            },
+          });
+        });
+      }
 
-      setQueryEntries(_queryEntries)
-      // setMetrics(_metrics);
-      // setMetricMeans(_metricMeans);
-      setTableColumns(columns)
+      setQueryEntries(_queryEntries);
+      setTableColumns(columns);
       setLoading(false);
     }
-  }, [experiment])
+  }, [experiment]);
 
   function resolve_attributes(ids, hits) {
-    const res = ids.map(id => hits.find(hit => hit._id === id) || {_id: id})
-    return res.map((x, index) => ({...x, rank: index + 1}))
+    const res = ids.map((id) => hits.find((hit) => hit._id === id) || { _id: id });
+    return res.map((x, index) => ({ ...x, rank: index + 1 }));
   }
 
   useEffect(() => {
-    if (selectedQuery != null) {
+    const { pairwiseMetrics } = extractMetricNames(experiment);
+    if (selectedQuery != null && pairwiseMetrics.length > 0) {
       const query1 = {
         index: searchConfigurations[0].index,
         query: {
-          terms: {
-            _id: queryEntries[selectedQuery].queryResults["0"]
-          }
-        }
-      }
+          ids: {
+            values: queryEntries[selectedQuery].queryResults['0'],
+          },
+        },
+      };
+
       const query2 = {
         index: searchConfigurations[1].index,
         query: {
-          terms: {
-            _id: queryEntries[selectedQuery].queryResults["1"]
-          }
-        }
-      }
+          ids: {
+            values: queryEntries[selectedQuery].queryResults['1'],
+          },
+        },
+      };
 
-      http.post(ServiceEndpoints.GetSearchResults, {
+      http
+        .post(ServiceEndpoints.GetSearchResults, {
           body: JSON.stringify({ query1, query2 }),
-      })
-      .then((res) => {
-        setQueryResult1(resolve_attributes(queryEntries[selectedQuery].queryResults["0"], convertFromSearchResult(res.result1)))
-        setQueryResult2(resolve_attributes(queryEntries[selectedQuery].queryResults["1"], convertFromSearchResult(res.result2)))
-      })
-      .catch((error: Error) => {
-          console.error(error);
-      });
+        })
+        .then((res) => {
+          console.log('Search response:', res);
 
+          // Debug logs
+          console.log('Query results before conversion:', {
+            result1: res.result1,
+            result2: res.result2,
+          });
+
+          const resolved1 = resolve_attributes(
+            queryEntries[selectedQuery].queryResults['0'],
+            convertFromSearchResult(res.result1)
+          );
+
+          const resolved2 = resolve_attributes(
+            queryEntries[selectedQuery].queryResults['1'],
+            convertFromSearchResult(res.result2)
+          );
+
+          console.log('After resolve_attributes:', {
+            resolved1,
+            resolved2,
+            queryEntries0: queryEntries[selectedQuery].queryResults['0'],
+            queryEntries1: queryEntries[selectedQuery].queryResults['1'],
+          });
+
+          setQueryResult1(resolved1);
+          setQueryResult2(resolved2);
+        })
+        .catch((error: Error) => {
+          console.error('Search error:', error);
+        });
     }
-  }, [selectedQuery])
+  }, [selectedQuery, experiment, searchConfigurations]);
 
   const findQueries = async (search: any) => {
-    const filteredQueryEntries = search ? queryEntries.filter(q => q.queryText.includes(search)) : queryEntries
-    return {hits: filteredQueryEntries, total: filteredQueryEntries.length}
-  }
+    const filteredQueryEntries = search
+      ? queryEntries.filter((q) => q.queryText.includes(search))
+      : queryEntries;
+    return { hits: filteredQueryEntries, total: filteredQueryEntries.length };
+  };
 
   const experimentDetails = (
     <EuiPanel hasBorder={true}>
@@ -249,64 +331,76 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
       <EuiResizableContainer>
         {(EuiResizablePanel, EuiResizableButton) => {
           return (
-          <>
-            <EuiResizablePanel initialSize={50} minSize="15%">
-              {error ? (
-                <EuiCallOut title="Error" color="danger">
-                  <p>{error}</p>
-                </EuiCallOut>
-              ) : (
-                <TableListView
-                  entityName="Query"
-                  entityNamePlural="Queries"
-                  tableColumns={tableColumns}
-                  findItems={findQueries}
-                  loading={loading}
-                  pagination={{
-                    initialPageSize: 10,
-                    pageSizeOptions: [5, 10, 20, 50],
-                  }}
-                  search={{
-                    box: {
-                      incremental: true,
-                      placeholder: 'Query...',
-                      schema: true,
-                    },
-                  }}
-                />
-              )}
-            </EuiResizablePanel>
+            <>
+              <EuiResizablePanel initialSize={50} minSize="15%">
+                {error ? (
+                  <EuiCallOut title="Error" color="danger">
+                    <p>{error}</p>
+                  </EuiCallOut>
+                ) : (
+                  <TableListView
+                    entityName="Query"
+                    entityNamePlural="Queries"
+                    tableColumns={tableColumns}
+                    findItems={findQueries}
+                    loading={loading}
+                    pagination={{
+                      initialPageSize: 10,
+                      pageSizeOptions: [5, 10, 20, 50],
+                    }}
+                    search={{
+                      box: {
+                        incremental: true,
+                        placeholder: 'Query...',
+                        schema: true,
+                      },
+                    }}
+                  />
+                )}
+              </EuiResizablePanel>
+              <EuiResizableButton />
 
-            <EuiResizableButton />
-
-            <EuiResizablePanel initialSize={50} minSize="30%">
-              {selectedQuery != null && queryResult1 && queryResult2 && (
-                <VisualComparison
-                  queryResult1={queryResult1}
-                  queryResult2={queryResult2}
-                  queryText={queryEntries[selectedQuery].queryText}
-                  resultText1={`${searchConfigurations[0].name} result`}
-                  resultText2={`${searchConfigurations[1].name} result`}
-                />
-              )}
-            </EuiResizablePanel>
-          </>
-        )}}
+              <EuiResizablePanel initialSize={50} minSize="30%">
+                {selectedQuery != null && queryResult1 && queryResult2 && (
+                  <VisualComparison
+                    queryResult1={queryResult1}
+                    queryResult2={queryResult2}
+                    queryText={queryEntries[selectedQuery].queryText}
+                    resultText1={`${searchConfigurations[0].name} result`}
+                    resultText2={`${searchConfigurations[1].name} result`}
+                  />
+                )}
+                {selectedQuery !== null &&
+                  experiment &&
+                  extractMetricNames(experiment).evaluationMetrics.length > 0 && (
+                    <EuiPanel hasBorder paddingSize="l">
+                      <EuiFlexGroup direction="column" gutterSize="m">
+                        <EuiFlexItem>
+                          <EvaluationMetricsTable
+                            queryText={queries[selectedQuery]}
+                            metrics={experiment.results.metrics[queries[selectedQuery]]}
+                            judgments={experiment.results.metrics[queries[selectedQuery]].judgments}
+                          />
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+                    </EuiPanel>
+                  )}
+              </EuiResizablePanel>
+            </>
+          );
+        }}
       </EuiResizableContainer>
     </EuiPanel>
   );
 
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="90%">
-      <EuiPageHeader
-        pageTitle="Experiment Visualization"
-      />
+      <EuiPageHeader pageTitle="Experiment Visualization" />
       {experimentDetails}
       <EuiSpacer size="l" />
       {resultsPane}
     </EuiPageTemplate>
   );
-
 };
 
 export const ExperimentViewWithRouter = withRouter(ExperimentView);

--- a/public/components/query_compare/evaluation_page.tsx
+++ b/public/components/query_compare/evaluation_page.tsx
@@ -1,0 +1,214 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import React, { useState } from 'react';
+import { LIGHT_THEME, Axis, Chart, LineSeries, Settings } from '@elastic/charts';
+import {
+  EuiPanel,
+  EuiTitle,
+  EuiFlexItem,
+  EuiComboBox,
+  EuiFilterButton,
+  EuiIcon,
+  EuiFlexGroup,
+  EuiButton,
+  EuiPageHeader,
+  EuiSpacer,
+  EuiSplitPanel, EuiStat, EuiTabbedContent, EuiBasicTable, EuiBasicTableColumn, EuiLink
+} from "@elastic/eui";
+
+
+import { Header } from '../common/header';
+import { CoreStart } from '../../../../../src/core/public';
+import { TEST_QUERY_ERROR, TEST_QUERY_RESPONSE, TEST_SEARCH_TEXT } from "../../../test/constants";
+import { SearchInputBar } from "./search_result/search_components/search_bar";
+import { ResultPanel } from "./search_result/result_components/result_panel";
+import { SearchRelevanceContextProvider } from "../../contexts";
+import { ResultPanels } from "./search_result/result_components/result_components";
+
+type EvaluationResult = {
+  name: string;
+  precision: number;
+  mrr: number;
+};
+
+const results: EvaluationResult[] = [];
+results.push({
+  name: 'querySet_sample01',
+  precision: 67,
+  mrr: 100
+});
+results.push({
+  name: 'querySet_sample02',
+  precision: 67,
+  mrr: 50
+});
+results.push({
+  name: 'querySet_sample03',
+  precision: 50,
+  mrr: 33
+});
+results.push({
+  name: 'querySet_sample04',
+  precision: 97,
+  mrr: 100
+});
+
+const columns: Array<EuiBasicTableColumn<EvaluationResult>> = [
+  {
+    field: 'name',
+    name: 'Name',
+    sortable: true,
+    truncateText: false,
+    mobileOptions: {
+      show: false,
+    },
+  },
+  {
+    field: 'precision',
+    name: 'Precision (%)',
+    truncateText: false,
+    mobileOptions: {
+      show: false,
+    },
+  },
+  {
+    field: 'mrr',
+    name: 'Mean Reciprocal Rank (%)',
+    truncateText: false,
+    mobileOptions: {
+      show: false,
+    },
+  }
+];
+
+const optionsStatic = [
+  {
+    label: 'querySet_sample01'
+  },
+  {
+    label: 'querySet_sample02'
+  },
+  {
+    label: 'querySet_sample03'
+  },
+  {
+    label: 'querySet_sample04'
+  }
+];
+const selectedOptions: any[] = [];
+selectedOptions.push(optionsStatic.at(0));
+selectedOptions.push(optionsStatic.at(1));
+selectedOptions.push(optionsStatic.at(2));
+selectedOptions.push(optionsStatic.at(3));
+
+const tabs = [
+  {
+    id: '01',
+    name: 'querySet_sample01',
+    content: ''
+  },
+  {
+    id: '02',
+    name: 'querySet_sample02',
+    content: ''
+  },
+  {
+    id: '03',
+    name: 'querySet_sample03',
+    content: ''
+  },
+  {
+    id: '04',
+    name: 'querySet_sample04',
+    content: ''
+  }
+]
+
+export const EvaluationPage = () => {
+  return (
+    <>
+      <Header />
+      <EuiFlexGroup wrap>
+        <EuiFlexItem grow={2}>
+          <EuiPanel paddingSize="l" hasBorder={true} hasShadow={false} grow={false}>
+            <EuiPageHeader
+              pageTitle="Select all querysets for evaluation"
+              rightSideItems={[
+                <EuiButton key="evaluate" fill iconType="lensApp" onClick={() => {}}>
+                  + Evaluate
+                </EuiButton>
+              ]}
+            />
+            <EuiSpacer size="m" />
+            <EuiComboBox
+              aria-label="Accessible screen reader label"
+              placeholder="Select or create options"
+              options={optionsStatic}
+              selectedOptions={selectedOptions}
+              isClearable={true}
+              data-test-subj="demoComboBox"
+              autoFocus
+              fullWidth
+            />
+            <EuiSpacer size="m" />
+            <EuiBasicTable
+              color="success"
+              tableCaption="Demo of EuiBasicTable"
+              items={results}
+              rowHeader="firstName"
+              columns={columns}
+            />
+            <Chart size={{height: 200}}>
+              <Settings
+                baseTheme={LIGHT_THEME}
+                showLegend={true}
+                legendPosition="right"
+                showLegendExtra={false}
+              />
+              <LineSeries
+                id="bars"
+                name="0"
+                data={[
+                  {x: 0, y: 67, g: 'querySet_sample01'},
+                  {x: 0, y: 100, g: 'querySet_sample01'},
+                  {x: 1, y: 67, g: 'querySet_sample02'},
+                  {x: 1, y: 50, g: 'querySet_sample02'},
+                  {x: 2, y: 50, g: 'querySet_sample03'},
+                  {x: 2, y: 33, g: 'querySet_sample03'},
+                  {x: 3, y: 97, g: 'querySet_sample04'},
+                  {x: 3, y: 100, g: 'querySet_sample04'}
+                ]}
+                xAccessor={'x'}
+                yAccessors={['y']}
+                splitSeriesAccessors={['g']}
+
+              />
+              <Axis
+                id="bottom-axis"
+                position="bottom"
+                gridLine={{ visible: true }}
+              />
+              <Axis
+                id="left-axis"
+                position="left"
+                gridLine={{ visible: true }}
+                tickFormat={(d) => Number(d).toFixed(2)}
+              />
+            </Chart>
+          </EuiPanel>
+          <EuiTabbedContent
+            tabs={tabs}
+            initialSelectedTab={tabs[0]}
+            autoFocus="selected"
+            onTabClick={(tab) => {
+              console.log('clicked tab', tab);
+            }}
+          />
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    </>
+  );
+};

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -1,5 +1,18 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React, { useState, useEffect, useRef } from 'react';
-import { EuiPanel, EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent, EuiSuperSelect, EuiFormRow } from '@elastic/eui';
+import {
+  EuiPanel,
+  EuiEmptyPrompt,
+  EuiPage,
+  EuiPageBody,
+  EuiPageContent,
+  EuiSuperSelect,
+  EuiFormRow,
+} from '@elastic/eui';
 
 import './visual_comparison.scss';
 import { ItemDetailHoverPane } from './item_detail_hover_pane';
@@ -22,11 +35,11 @@ export const convertFromSearchResult = (searchResult) => {
 
   return searchResult.hits.hits.map((x, index) => ({
     _id: x._id,
-    _score: x._score, 
+    _score: x._score,
     rank: index + 1,
-    ...x._source
+    ...x._source,
   }));
-}
+};
 
 export const VisualComparison = ({
   queryResult1,
@@ -40,11 +53,9 @@ export const VisualComparison = ({
   // State for selected display field
   const [displayField, setDisplayField] = useState('_id');
   const [imageFieldName, setImageFieldName] = useState(null);
-  
+
   // Available fields for display - will be updated based on actual data
-  const [displayFields, setDisplayFields] = useState([
-    { value: '_id', label: 'ID' }
-  ]);
+  const [displayFields, setDisplayFields] = useState([{ value: '_id', label: 'ID' }]);
 
   // State for hover item details
   const [hoveredItem, setHoveredItem] = useState(null);
@@ -54,12 +65,12 @@ export const VisualComparison = ({
   // Refs for elements
   const result1ItemsRef = useRef({});
   const result2ItemsRef = useRef({});
-  
+
   // State to track if component has mounted
   const [mounted, setMounted] = useState(false);
   // State to track if we have valid results
   const [initialState, setInitialState] = useState(true);
-  
+
   // Process the results into the format we need
   const [result1, setResult1] = useState([]);
   const [result2, setResult2] = useState([]);
@@ -72,7 +83,7 @@ export const VisualComparison = ({
     onlyInResult2: 0,
     unchanged: 0,
     improved: 0,
-    worsened: 0
+    worsened: 0,
   });
 
   const vennDiagram = (
@@ -82,13 +93,13 @@ export const VisualComparison = ({
         <div className="venn-value">{statistics.onlyInResult1}</div>
         <div className="venn-label">Unique</div>
       </div>
-      
+
       {/* Intersection (middle) */}
       <div className="venn-middle">
         <div className="venn-value">{statistics.inBoth}</div>
         <div className="venn-label">Common</div>
       </div>
-      
+
       {/* Result 2 rectangle (right) */}
       <div className="venn-right">
         <div className="venn-value">{statistics.onlyInResult2}</div>
@@ -118,26 +129,22 @@ export const VisualComparison = ({
       const sampleItem = queryResult1[0] || queryResult2[0];
       if (sampleItem) {
         const fields = Object.keys(sampleItem)
-          .filter(key => !key.startsWith('_')) // Exclude hidden fields
-          .filter(key =>
-            typeof sampleItem[key]==='string'
-          )
-          .map(key => ({ value: key, label: key.charAt(0).toUpperCase() + key.slice(1) }));
-        
+          .filter((key) => !key.startsWith('_')) // Exclude hidden fields
+          .filter((key) => typeof sampleItem[key] === 'string')
+          .map((key) => ({ value: key, label: key.charAt(0).toUpperCase() + key.slice(1) }));
+
         // Find a field that might contain image names or URLs
         let imageField = null;
         if (sampleItem) {
           // Look for fields with common image-related names
           const possibleImageFields = ['image', 'img', 'thumbnail', 'picture', 'photo', 'avatar'];
-          imageField = Object.keys(sampleItem).find(key =>
-            possibleImageFields.some(imgField =>
-              key.toLowerCase().includes(imgField)
-            )
+          imageField = Object.keys(sampleItem).find((key) =>
+            possibleImageFields.some((imgField) => key.toLowerCase().includes(imgField))
           );
 
           // If no obvious image field found, look for fields with URL patterns that might be images
           if (!imageField) {
-            imageField = Object.keys(sampleItem).find(key => {
+            imageField = Object.keys(sampleItem).find((key) => {
               const value = String(sampleItem[key] || '');
               return (
                 value.match(/\.(jpg|jpeg|png|gif|svg|webp)($|\?)/i) ||
@@ -156,10 +163,7 @@ export const VisualComparison = ({
         }
 
         // Always include _id at the beginning
-        setDisplayFields([
-          { value: '_id', label: 'ID' },
-          ...fields
-        ]);
+        setDisplayFields([{ value: '_id', label: 'ID' }, ...fields]);
 
         // Optionally set a preferred display field if an image field was found
         if (imageField) {
@@ -177,8 +181,8 @@ export const VisualComparison = ({
     const combined = [...result1];
 
     // Add items that are only in result2
-    result2.forEach(item2 => {
-      const exists = combined.some(item => item._id === item2._id);
+    result2.forEach((item2) => {
+      const exists = combined.some((item) => item._id === item2._id);
       if (!exists) {
         combined.push(item2);
       }
@@ -187,21 +191,20 @@ export const VisualComparison = ({
     setCombinedData(combined);
 
     // Calculate summary statistics
-    const inBoth = result1.filter(item1 => 
-      result2.some(item2 => item2._id === item1._id)
-    ).length;
+    const inBoth = result1.filter((item1) => result2.some((item2) => item2._id === item1._id))
+      .length;
     const onlyInResult1 = result1.length - inBoth;
     const onlyInResult2 = result2.length - inBoth;
-    const unchanged = result1.filter(item1 => {
-      const item2 = result2.find(item2 => item2._id === item1._id);
+    const unchanged = result1.filter((item1) => {
+      const item2 = result2.find((item2) => item2._id === item1._id);
       return item2 && item1.rank === item2.rank;
     }).length;
-    const improved = result1.filter(item1 => {
-      const item2 = result2.find(item2 => item2._id === item1._id);
+    const improved = result1.filter((item1) => {
+      const item2 = result2.find((item2) => item2._id === item1._id);
       return item2 && item1.rank > item2.rank;
     }).length;
-    const worsened = result1.filter(item1 => {
-      const item2 = result2.find(item2 => item2._id === item1._id);
+    const worsened = result1.filter((item1) => {
+      const item2 = result2.find((item2) => item2._id === item1._id);
       return item2 && item1.rank < item2.rank;
     }).length;
 
@@ -211,32 +214,32 @@ export const VisualComparison = ({
       onlyInResult2,
       unchanged,
       improved,
-      worsened
+      worsened,
     });
   }, [result1, result2]);
 
-  // Update lines on window resize and after mounting  
+  // Update lines on window resize and after mounting
   useEffect(() => {
     // Mark component as mounted
     setMounted(true);
-    
+
     // Force re-render when window is resized to recalculate line positions
     const handleResize = () => {
       // Force a re-render by setting state
-      setDisplayField(curr => curr);
+      setDisplayField((curr) => curr);
     };
-    
+
     window.addEventListener('resize', handleResize);
     return () => window.removeEventListener('resize', handleResize);
   }, []);
-  
+
   // Update lines after component mounts to ensure all refs are loaded
   useEffect(() => {
     // Small delay to ensure DOM is fully rendered
     const timer = setTimeout(() => {
-      setDisplayField(curr => curr); // Force re-render
+      setDisplayField((curr) => curr); // Force re-render
     }, 100);
-    
+
     return () => clearTimeout(timer);
   }, [mounted]);
 
@@ -244,20 +247,20 @@ export const VisualComparison = ({
   const getStatusColor = (item, resultNum) => {
     if (resultNum === 1) {
       // For Result 1 items
-      const matchingItem = result2.find(r2 => r2._id === item._id);
-      if (!matchingItem) return "bg-yellow-300"; // Only in Result 1
-      
-      if (item.rank === matchingItem.rank) return "bg-blue-300"; // Same position
-      if (item.rank < matchingItem.rank) return "bg-red-300"; // Dropped in Result 2
-      return "bg-green-300"; // Improved in Result 2
+      const matchingItem = result2.find((r2) => r2._id === item._id);
+      if (!matchingItem) return 'bg-yellow-300'; // Only in Result 1
+
+      if (item.rank === matchingItem.rank) return 'bg-blue-300'; // Same position
+      if (item.rank < matchingItem.rank) return 'bg-red-300'; // Dropped in Result 2
+      return 'bg-green-300'; // Improved in Result 2
     } else {
       // For Result 2 items
-      const matchingItem = result1.find(r1 => r1._id === item._id);
-      if (!matchingItem) return "bg-purple-300"; // Only in Result 2
-      
-      if (item.rank === matchingItem.rank) return "bg-blue-300"; // Same position
-      if (item.rank > matchingItem.rank) return "bg-red-300"; // Improved from Result 1
-      return "bg-green-300"; // Dropped from Result 1
+      const matchingItem = result1.find((r1) => r1._id === item._id);
+      if (!matchingItem) return 'bg-purple-300'; // Only in Result 2
+
+      if (item.rank === matchingItem.rank) return 'bg-blue-300'; // Same position
+      if (item.rank > matchingItem.rank) return 'bg-red-300'; // Improved from Result 1
+      return 'bg-green-300'; // Dropped from Result 1
     }
   };
 
@@ -302,20 +305,29 @@ export const VisualComparison = ({
     <EuiPage>
       <EuiPageBody>
         <EuiPageContent>
-          <h3 className="text-lg font-semibold mb-2">Results for query: <em>{queryText}</em></h3>
+          <h3 className="text-lg font-semibold mb-2">
+            Results for query: <em>{queryText}</em>
+          </h3>
 
           {/* Field selector dropdown */}
           <div className="mb-4">
             <EuiFormRow label="Display Field:" id="fieldSelectorForm">
               <EuiSuperSelect
                 id="field-selector"
-                options={displayFields && displayFields.length > 0 
-                  ? displayFields.map((field) => ({
-                      value: field.value,
-                      inputDisplay: field.label,
-                      dropdownDisplay: field.label,
-                    }))
-                  : [{ value: '', inputDisplay: 'No fields available', dropdownDisplay: 'No fields available' }]
+                options={
+                  displayFields && displayFields.length > 0
+                    ? displayFields.map((field) => ({
+                        value: field.value,
+                        inputDisplay: field.label,
+                        dropdownDisplay: field.label,
+                      }))
+                    : [
+                        {
+                          value: '',
+                          inputDisplay: 'No fields available',
+                          dropdownDisplay: 'No fields available',
+                        },
+                      ]
                 }
                 valueOfSelected={displayField}
                 onChange={(value) => setDisplayField(value)}
@@ -326,9 +338,7 @@ export const VisualComparison = ({
           </div>
 
           {/* Summary section with Venn diagram style using CSS classes */}
-          <div className="mb-6">
-            {vennDiagram}
-          </div>
+          <div className="mb-6">{vennDiagram}</div>
 
           {/* Rank-based overlap visualization */}
           <div className="mb-6">
@@ -361,7 +371,7 @@ export const VisualComparison = ({
 
               {/* Connection lines */}
               <div className="w-1/3 relative">
-                <ConnectionLines 
+                <ConnectionLines
                   mounted={mounted}
                   result1={result1}
                   result2={result2}
@@ -392,19 +402,19 @@ export const VisualComparison = ({
 
           <div className="mt-4 flex gap-4 text-sm">
             <div className="flex items-center">
-              <div className="w-4 h-4 bg-blue-300 mr-1"></div> Same position
+              <div className="w-4 h-4 bg-blue-300 mr-1" /> Same position
             </div>
             <div className="flex items-center">
-              <div className="w-4 h-4 bg-green-300 mr-1"></div> Improved position
+              <div className="w-4 h-4 bg-green-300 mr-1" /> Improved position
             </div>
             <div className="flex items-center">
-              <div className="w-4 h-4 bg-red-300 mr-1"></div> Dropped position
+              <div className="w-4 h-4 bg-red-300 mr-1" /> Dropped position
             </div>
             <div className="flex items-center">
-              <div className="w-4 h-4 bg-yellow-300 mr-1"></div> Only in {resultText1}
+              <div className="w-4 h-4 bg-yellow-300 mr-1" /> Only in {resultText1}
             </div>
             <div className="flex items-center">
-              <div className="w-4 h-4 bg-purple-300 mr-1"></div> Only in {resultText2}
+              <div className="w-4 h-4 bg-purple-300 mr-1" /> Only in {resultText2}
             </div>
           </div>
 

--- a/public/components/resource_management_home/resource_management_tabs.tsx
+++ b/public/components/resource_management_home/resource_management_tabs.tsx
@@ -99,7 +99,7 @@ export const ResourceManagementTabs = ({
               ) : (
                 <></>
               )}
-              {entityAction === 'view' ? <ExperimentViewWithRouter http={http} id={entityId} /> : <></>}
+              {entityAction === 'view' ? <ExperimentViewWithRouter http={http} id={entityId} history={history}/> : <></>}
               {selectedSubTabs === 'create' ? <TemplateCards onClose={() => {}} /> : <></>}
             </EuiPanel>
           </>

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -58,7 +58,7 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         const start = performance.now();
         try {
           let resp;
-          const invalidCharactersPattern = /[\s,:\"*+\/\\|?#><]/;
+          const invalidCharactersPattern = /[\s,\"*+\/\\|?#><]/;
           if (
             index !== index.toLowerCase() ||
             index.startsWith('_') ||
@@ -135,7 +135,7 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         const start = performance.now();
         try {
           let resp;
-          const invalidCharactersPattern = /[\s,:\"*+\/\\|?#><]/;
+          const invalidCharactersPattern = /[\s,\"*+\/\\|?#><]/;
           if (
             index !== index.toLowerCase() ||
             index.startsWith('_') ||
@@ -218,7 +218,26 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
         } else {
           callApi = context.core.opensearch.legacy.client.callAsCurrentUser;
         }
-        const resp = await callApi('cat.indices', params);
+        let resp = await callApi('cat.indices', params); // local indexes
+        const remoteConnections = await callApi('transport.request', {
+          method: 'GET',
+          path: '/_remote/info',
+        });
+        if (Object.keys(remoteConnections).length > 0) {
+          // fetch remote indices if remote clusters exist
+          const remoteClusters = Object.keys(remoteConnections)
+            .map((key) => `${key}:*`)
+            .join(',');
+          const resolveResponse = await callApi('transport.request', {
+            method: 'GET',
+            path: `/_resolve/index/${remoteClusters}`,
+          });
+          const remoteIndices = resolveResponse.indices.map((item: { name: string }) => ({
+            index: item.name,
+            format: 'json',
+          }));
+          resp = resp.concat(remoteIndices);
+        }
         const end = performance.now();
         context.searchRelevance.metricsService.addMetric(
           METRIC_NAME.SEARCH_RELEVANCE,


### PR DESCRIPTION
### Description
This PR will support LLM-as-a-judgment template, from creating a LLM form to evaluation metrics experiment view.

**Major changed components:**
- Experiment Create Page
- Experiment View Page

### Test
- now, it will support two types of experiments, quality evaluation or pairwise comparison
<img width="1746" alt="Screenshot 2025-05-02 at 4 26 15 PM" src="https://github.com/user-attachments/assets/7d04721a-b073-464c-a8df-be3e00c05a66" />

- the evaluation experiment view page looks like this
<img width="1122" alt="Screenshot 2025-05-02 at 4 26 59 PM" src="https://github.com/user-attachments/assets/83bf3de5-f5ed-4b8e-aa9f-b65c14ca5308" />


### Issues Resolved
- https://github.com/o19s/search-relevance/issues/89

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
