### PR TITLE
Limit inputs

### DIFF
--- a/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
+++ b/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
@@ -60,10 +60,10 @@ export const ResultListComparisonForm = ({
             onChange={handleQuerySetsChange}
             isClearable
             isInvalid={formData.querySets.length === 0}
+            singleSelection={{ asPlainText: true }}
             isLoading={isLoading}
             async
             fullWidth
-            multi
           />
         </EuiFormRow>
       </EuiFlexItem>

--- a/public/components/experiment_create/configuration/search_configuration_form.tsx
+++ b/public/components/experiment_create/configuration/search_configuration_form.tsx
@@ -53,7 +53,11 @@ export const SearchConfigForm = ({ formData, onChange, http }: SearchConfigFormP
             placeholder="Select search configuration"
             options={searchConfigOptions}
             selectedOptions={formData.searchConfigs || []}
-            onChange={handleSearchConfigsChange}
+            onChange={(selected) => {
+              if (selected.length <= 2) {
+                handleSearchConfigsChange(selected);
+              }
+            }}
             isClearable={true}
             isInvalid={(formData.searchConfigs || []).length === 0}
             isLoading={isLoadingConfigs}


### PR DESCRIPTION
### Description
Limit inputs in pairwise experiment creation to allow a single query set and two search configurations.

### Issues Resolved
Closes: https://github.com/o19s/search-relevance/issues/84

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
