### PR TITLE
 Search Configuration to take whole DSL query and support hybrid search with search_pipeline

### DIFF
--- a/public/components/search_config_create/search_config_create.tsx
+++ b/public/components/search_config_create/search_config_create.tsx
@@ -33,8 +33,8 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
   // Form state
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState('');
-  const [queryBody, setQueryBody] = useState('');
-  const [queryBodyError, setQueryBodyError] = useState('');
+  const [query, setQuery] = useState('');
+  const [queryError, setQueryError] = useState('');
   const [searchPipeline, setSearchPipeline] = useState('');
   const [searchTemplate, setSearchTemplate] = useState('');
 
@@ -77,15 +77,15 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
       setNameError('');
     }
 
-    if (!queryBody.trim()) {
-      setQueryBodyError('Query Body is required.');
+    if (!query.trim()) {
+      setQueryError('Query is required.');
       isValid = false;
     } else {
       try {
-        JSON.parse(queryBody);
-        setQueryBodyError('');
+        JSON.parse(query);
+        setQueryError('');
       } catch (e) {
-        setQueryBodyError('Query Body must be valid JSON.');
+        setQueryError('Query Body must be valid JSON.');
         isValid = false;
       }
     }
@@ -109,7 +109,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
         body: JSON.stringify({
           name,
           index: selectedIndex[0].label,
-          queryBody,
+          query,
         }),
       })
       .then((response) => {
@@ -121,7 +121,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
           title: 'Failed to create search configuration',
         });
       });
-  }, [name, queryBody, searchPipeline, searchTemplate, history, notifications.toasts, selectedIndex]);
+  }, [name, query, searchPipeline, searchTemplate, history, notifications.toasts, selectedIndex]);
 
   // Handle cancel action
   const handleCancel = () => {
@@ -202,10 +202,10 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
               setName={setName}
               nameError={nameError}
               validateName={validateName}
-              queryBody={queryBody}
-              setQueryBody={setQueryBody}
-              queryBodyError={queryBodyError}
-              setQueryBodyError={setQueryBodyError}
+              query={query}
+              setQuery={setQuery}
+              queryError={queryError}
+              setQueryError={setQueryError}
               setSearchPipeline={setSearchPipeline}
               searchTemplate={searchTemplate}
               setSearchTemplate={setSearchTemplate}
@@ -223,7 +223,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
         <EuiFlexItem grow={5} style={{ maxWidth: '41.67%', maxHeight: '80vh', overflow: 'auto' }}>
           <ValidationPanel
             selectedIndex={selectedIndex}
-            queryBody={queryBody}
+            query={query}
             http={http}
             notifications={notifications}
           />

--- a/public/components/search_config_create/search_config_create.tsx
+++ b/public/components/search_config_create/search_config_create.tsx
@@ -35,12 +35,15 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
   const [nameError, setNameError] = useState('');
   const [query, setQuery] = useState('');
   const [queryError, setQueryError] = useState('');
-  const [searchPipeline, setSearchPipeline] = useState('');
   const [searchTemplate, setSearchTemplate] = useState('');
 
   const [indexOptions, setIndexOptions] = useState<Array<{ label: string; value: string }>>([]);
   const [selectedIndex, setSelectedIndex] = useState<Array<{ label: string; value: string }>>([]);
   const [isLoadingIndexes, setIsLoadingIndexes] = useState(true);
+
+  const [pipelineOptions, setPipelineOptions] = useState<Array<{ label: string }>>([]);
+  const [selectedPipeline, setSelectedPipeline] = useState<Array<{ label: string }>>([]);
+  const [isLoadingPipelines, setIsLoadingPipelines] = useState(false);
 
   useEffect(() => {
     const fetchIndexes = async () => {
@@ -110,6 +113,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
           name,
           index: selectedIndex[0].label,
           query,
+          searchPipeline: selectedPipeline.length > 0 ? selectedPipeline[0].label : '',
         }),
       })
       .then((response) => {
@@ -121,7 +125,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
           title: 'Failed to create search configuration',
         });
       });
-  }, [name, query, searchPipeline, searchTemplate, history, notifications.toasts, selectedIndex]);
+  }, [name, query, searchTemplate, history, notifications.toasts, selectedIndex, selectedPipeline]);
 
   // Handle cancel action
   const handleCancel = () => {
@@ -138,10 +142,6 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
     }
   };
 
-  const [pipelineOptions, setPipelineOptions] = useState<Array<{ label: string }>>([]);
-  const [selectedPipeline, setSelectedPipeline] = useState<Array<{ label: string }>>([]);
-  const [isLoadingPipelines, setIsLoadingPipelines] = useState(false);
-
   const fetchPipelines = async () => {
     setIsLoadingPipelines(true);
     try {
@@ -150,13 +150,6 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
         label: pipelineId,
       }));
       setPipelineOptions(options);
-
-      // If there's an existing searchPipeline value, set it as selected
-      if (searchPipeline) {
-        setSelectedPipeline([{
-           label: searchPipeline,
-        }]);
-      }
     } catch (error) {
       notifications.toasts.addDanger('Failed to fetch search pipelines');
     } finally {
@@ -206,7 +199,6 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
               setQuery={setQuery}
               queryError={queryError}
               setQueryError={setQueryError}
-              setSearchPipeline={setSearchPipeline}
               searchTemplate={searchTemplate}
               setSearchTemplate={setSearchTemplate}
               indexOptions={indexOptions}
@@ -223,6 +215,7 @@ export const SearchConfigurationCreate: React.FC<SearchConfigurationCreateProps>
         <EuiFlexItem grow={5} style={{ maxWidth: '41.67%', maxHeight: '80vh', overflow: 'auto' }}>
           <ValidationPanel
             selectedIndex={selectedIndex}
+            selectedPipeline={selectedPipeline}
             query={query}
             http={http}
             notifications={notifications}

--- a/public/components/search_config_create/search_configuration_form.tsx
+++ b/public/components/search_config_create/search_configuration_form.tsx
@@ -17,10 +17,10 @@ interface SearchConfigurationFormProps {
   setName: (name: string) => void;
   nameError: string;
   validateName: (e: React.FocusEvent<HTMLInputElement>) => void;
-  queryBody: string;
-  setQueryBody: (queryBody: string) => void;
-  queryBodyError: string;
-  setQueryBodyError: (error: string) => void;
+  query: string;
+  setQuery: (queryBody: string) => void;
+  queryError: string;
+  setQueryError: (error: string) => void;
   searchPipeline: string;
   setSearchPipeline: (pipeline: string) => void;
   searchTemplate: string;
@@ -41,10 +41,10 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
   setName,
   nameError,
   validateName,
-  queryBody,
-  setQueryBody,
-  queryBodyError,
-  setQueryBodyError,
+  query,
+  setQuery,
+  queryError,
+  setQueryError,
   setSearchPipeline,
   searchTemplate,
   setSearchTemplate,
@@ -58,7 +58,7 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
   isLoadingPipelines,
   disabled = false,
 }) => (
-  <EuiForm component="form" isInvalid={Boolean(nameError || queryBodyError)}>
+  <EuiForm component="form" isInvalid={Boolean(nameError || queryError)}>
     <EuiFormRow
       label="Search Configuration Name"
       error={nameError}
@@ -97,10 +97,10 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
     </EuiFormRow>
 
     <EuiFormRow
-      label="Query Body"
-      error={queryBodyError}
-      isInvalid={Boolean(queryBodyError)}
-      helpText="Define the query body in JSON format.  Use %SearchText% to represent the specific query text."
+      label="Query"
+      error={queryError}
+      isInvalid={Boolean(queryError)}
+      helpText="Define the query in JSON format.  Use %SearchText% to represent the specific query text."
       fullWidth
     >
       <EuiCodeEditor
@@ -108,15 +108,15 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
         mode="json"
         theme="github"
         width="100%"
-        value={queryBody}
+        value={query}
         onChange={(value) => {
           if (disabled) return;
           try {
             JSON.parse(value);
-            setQueryBody(value);
-            setQueryBodyError('');
+            setQuery(value);
+            setQueryError('');
           } catch {
-            setQueryBody(value);
+            setQuery(value);
           }
         }}
         setOptions={{
@@ -126,18 +126,18 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
         }}
         onBlur={() => {
           if (disabled) return;
-          if (!queryBody.trim()) {
-            setQueryBodyError('Query Body is required.');
+          if (!query.trim()) {
+            setQueryError('Query is required.');
           } else {
             try {
-              JSON.parse(queryBody);
-              setQueryBodyError('');
+              JSON.parse(query);
+              setQueryError('');
             } catch {
-              setQueryBodyError('Query Body must be valid JSON.');
+              setQueryError('Query must be valid JSON.');
             }
           }
         }}
-        isInvalid={Boolean(queryBodyError)}
+        isInvalid={Boolean(queryError)}
         aria-label="Code Editor"
       />
     </EuiFormRow>

--- a/public/components/search_config_create/search_configuration_form.tsx
+++ b/public/components/search_config_create/search_configuration_form.tsx
@@ -21,8 +21,6 @@ interface SearchConfigurationFormProps {
   setQuery: (queryBody: string) => void;
   queryError: string;
   setQueryError: (error: string) => void;
-  searchPipeline: string;
-  setSearchPipeline: (pipeline: string) => void;
   searchTemplate: string;
   setSearchTemplate: (template: string) => void;
   indexOptions: Array<{ label: string; value: string }>;
@@ -45,7 +43,6 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
   setQuery,
   queryError,
   setQueryError,
-  setSearchPipeline,
   searchTemplate,
   setSearchTemplate,
   indexOptions,
@@ -149,7 +146,6 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
         selectedOptions={selectedPipeline}
         onChange={(selected) => {
           setSelectedPipeline(selected);
-          setSearchPipeline(selected[0]?.label || '');
         }}
         singleSelection={{ asPlainText: true }}
         isLoading={isLoadingPipelines}

--- a/public/components/search_config_create/validation_panel.tsx
+++ b/public/components/search_config_create/validation_panel.tsx
@@ -11,6 +11,7 @@ import { ResultsPanel } from './results_panel';
 
 interface ValidationPanelProps {
   selectedIndex: Array<{ label: string }>;
+  selectedPipeline: Array<{ label: string }>;
   query: string;
   http: CoreStart['http'];
   notifications: NotificationsStart;
@@ -18,6 +19,7 @@ interface ValidationPanelProps {
 
 export const ValidationPanel: React.FC<ValidationPanelProps> = ({
   selectedIndex,
+  selectedPipeline,
   query,
   http,
   notifications,
@@ -50,6 +52,11 @@ export const ValidationPanel: React.FC<ValidationPanelProps> = ({
           ...queryBody,
         },
       };
+
+      // Add the pipeline to the request if it's selected
+      if (selectedPipeline.length > 0) {
+        requestBody.query.search_pipeline = selectedPipeline[0].label;
+      }
 
       const response = await http.post(ServiceEndpoints.GetSingleSearchResults, {
         body: JSON.stringify(requestBody),

--- a/public/components/search_config_create/validation_panel.tsx
+++ b/public/components/search_config_create/validation_panel.tsx
@@ -11,14 +11,14 @@ import { ResultsPanel } from './results_panel';
 
 interface ValidationPanelProps {
   selectedIndex: Array<{ label: string }>;
-  queryBody: string;
+  query: string;
   http: CoreStart['http'];
   notifications: NotificationsStart;
 }
 
 export const ValidationPanel: React.FC<ValidationPanelProps> = ({
   selectedIndex,
-  queryBody,
+  query,
   http,
   notifications,
 }) => {
@@ -32,21 +32,22 @@ export const ValidationPanel: React.FC<ValidationPanelProps> = ({
       return;
     }
 
-    if (!queryBody.trim()) {
+    if (!query.trim()) {
       notifications.toasts.addWarning({title: 'Validation Warning', text: 'Query body is required'});
       return;
     }
 
     try {
       setIsValidating(true);
-      const replacedQueryBody = queryBody.replace(/%SearchText%/g, testSearchText || '');
-      const parsedQuery = JSON.parse(replacedQueryBody);
+      const replacedQuery = query.replace(/%SearchText%/g, testSearchText || '');
+      const parsedQuery = JSON.parse(replacedQuery);
+      const queryBody = parsedQuery.query ? parsedQuery : { query: parsedQuery };
 
       const requestBody = {
         query: {
           index: selectedIndex[0].label,
           size: 5, // hard-coded to return 5 items
-          query: parsedQuery,
+          ...queryBody,
         },
       };
 

--- a/public/components/search_config_listing/search_config_listing.tsx
+++ b/public/components/search_config_listing/search_config_listing.tsx
@@ -73,11 +73,11 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
       sortable: true,
     },
     {
-      field: 'query_body',
-      name: 'Query Body',
+      field: 'query',
+      name: 'Query',
       dataType: 'string',
       sortable: false,
-      render: (queryBody: string) => (
+      render: (query: string) => (
         <EuiText
           size="s"
           style={{
@@ -87,7 +87,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
             textOverflow: 'ellipsis',
           }}
         >
-          {queryBody}
+          {query}
         </EuiText>
       ),
     },
@@ -151,7 +151,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
       id: obj._source.id,
       search_configuration_name: obj._source.name,
       index: obj._source.index,
-      query_body: obj._source.queryBody,
+      query: obj._source.query,
       timestamp: obj._source.timestamp,
     };
   };

--- a/public/components/search_config_view/search_config_view.tsx
+++ b/public/components/search_config_view/search_config_view.tsx
@@ -73,12 +73,12 @@ export const SearchConfigurationView: React.FC<SearchConfigurationViewProps> = (
           </EuiCodeBlock>
         </EuiFormRow>
 
-        {(searchConfiguration.pipeline || searchConfiguration.template) && (
+        {(searchConfiguration.searchPipeline || searchConfiguration.template) && (
           <EuiDescriptionList type="column" compressed>
-            {searchConfiguration.pipeline && (
+            {searchConfiguration.searchPipeline && (
               <>
                 <EuiDescriptionListTitle>Search Pipeline</EuiDescriptionListTitle>
-                <EuiDescriptionListDescription>{searchConfiguration.pipeline}</EuiDescriptionListDescription>
+                <EuiDescriptionListDescription>{searchConfiguration.searchPipeline}</EuiDescriptionListDescription>
               </>
             )}
             {searchConfiguration.template && (

--- a/public/components/search_config_view/search_config_view.tsx
+++ b/public/components/search_config_view/search_config_view.tsx
@@ -59,7 +59,7 @@ export const SearchConfigurationView: React.FC<SearchConfigurationViewProps> = (
         </EuiFormRow>
 
         <EuiFormRow
-          label="Query Body"
+          label="Query"
           fullWidth
         >
           <EuiCodeBlock
@@ -69,7 +69,7 @@ export const SearchConfigurationView: React.FC<SearchConfigurationViewProps> = (
             isCopyable={true}
             whiteSpace="pre"
           >
-            {formatJson(searchConfiguration.queryBody)}
+            {formatJson(searchConfiguration.query)}
           </EuiCodeBlock>
         </EuiFormRow>
 

--- a/server/routes/dsl_route.ts
+++ b/server/routes/dsl_route.ts
@@ -314,10 +314,11 @@ export function registerDslRoute(router: IRouter, dataSourceEnabled: boolean) {
       const { query, dataSourceId } = request.body;
       const resBody: SearchResultResponse = {};
 
-      const { index, size, ...rest } = query;
+      const { index, size, search_pipeline, ...rest } = query;
       const params: RequestParams.Search = {
         index,
         size,
+        search_pipeline,
         body: rest,
       };
 


### PR DESCRIPTION
### Description
- UI matching with backend changes to support full DSL
- backend PR - https://github.com/o19s/search-relevance/pull/102

### Tests
able to create search configuration with hybrid search and execute the pairwise experiment
```
{"_source":{"exclude":["passage_embedding"]},"query":{"hybrid":{"queries":[{"match":{"name":"apple"}},{"match":{"name":{"query":"apple"}}}]}},"search_pipeline":{"description":"Post processor for hybrid search","phase_results_processors":[{"normalization-processor":{"normalization":{"technique":"min_max"},"combination":{"technique":"arithmetic_mean","parameters":{"weights":[0.7,0.3]}}}}]}}
```

### Issues Resolved
- https://github.com/o19s/search-relevance/issues/83

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
