### PR TITLE
Rename Judgement to Judgement Set to reflect it is a grouping of Judgments

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -19,7 +19,7 @@ export const SearchRelevanceApp = () => {
               <Route
                 path={[
                   '/',
-                  '/:entity(querySet|searchConfiguration|experiment|judgment)/:entityAction(list|create|view)?/:entityId?',
+                  '/:entity(querySet|searchConfiguration|experiment|judgmentSet)/:entityAction(list|create|view)?/:entityId?',
                 ]}
                 exact
                 render={(props) => {

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -28,7 +28,7 @@ const getInitialFormData = (templateType: string): ConfigurationFormData => {
     case 'Search Evaluation':
       return {
         ...baseData,
-        judgmentList: [],
+        judgmentSetList: [],
         type: "UBI_EVALUATION",
       };
     default:
@@ -87,7 +87,7 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
             <EuiFlexGroup justifyContent="flexEnd">
               <EuiFlexItem grow={false}>
                 <EuiFormRow hasEmptyLabelSpace>
-                  <EuiButton onClick={handleSave}>Save Judgement</EuiButton>
+                  <EuiButton onClick={handleSave}>Save Judgment Set</EuiButton>
                 </EuiFormRow>
               </EuiFlexItem>
             </EuiFlexGroup>

--- a/public/components/experiment_create/configuration/form/judgment_sets_combo_box.tsx
+++ b/public/components/experiment_create/configuration/form/judgment_sets_combo_box.tsx
@@ -4,45 +4,45 @@ import { IndexOption } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../../../common';
 
-interface JudgmentsComboBoxProps {
-  selectedOptions: JudgmentOption[];
-  onChange: (selectedOptions: JudgmentOption[]) => void;
+interface JudgmentSetsComboBoxProps {
+  selectedOptions: JudgmentSetOption[];
+  onChange: (selectedOptions: JudgmentSetOption[]) => void;
   http: CoreStart['http'];
 }
 
-export const JudgmentsComboBox = ({
+export const JudgmentSetsComboBox = ({
   selectedOptions,
   onChange,
   http,
-}: JudgmentsComboBoxProps) => {
-  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
+}: JudgmentSetsComboBoxProps) => {
+  const [judgmentSetOptions, setJudgmentSetOptions] = useState<IndexOption[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
 
   useEffect(() => {
-    const fetchJudgments = async () => {
+    const fetchJudgmentSets = async () => {
       try {
         const data = await http.get(ServiceEndpoints.Judgments);
-        const options = data.hits.hits.map((judgment: any) => ({
-          label: judgment._source.name,
-          value: judgment._source.id,
+        const options = data.hits.hits.map((judgmentSet: any) => ({
+          label: judgmentSet._source.name,
+          value: judgmentSet._source.id,
         }));
-        setJudgmentOptions(options);
+        setJudgmentSetOptions(options);
       } catch (error) {
-        console.error('Failed to fetch judgments', error);
-        setJudgmentOptions([]);
+        console.error('Failed to fetch judgment sets', error);
+        setJudgmentSetOptions([]);
       } finally {
         setIsLoading(false);
       }
     };
 
-    fetchJudgments();
+    fetchJudgmentSets();
   }, [http]);
 
   return (
-    <EuiFormRow label="Judgments">
+    <EuiFormRow label="Judgment Sets">
       <EuiComboBox
-        placeholder={isLoading ? 'Loading...' : 'Select judgments'}
-        options={judgmentOptions}
+        placeholder={isLoading ? 'Loading...' : 'Select judgment sets'}
+        options={judgmentSetOptions}
         selectedOptions={selectedOptions}
         onChange={onChange}
         isClearable
@@ -54,4 +54,4 @@ export const JudgmentsComboBox = ({
       />
     </EuiFormRow>
   );
-}; 
+};

--- a/public/components/experiment_create/configuration/form/user_behavior_form.tsx
+++ b/public/components/experiment_create/configuration/form/user_behavior_form.tsx
@@ -4,7 +4,7 @@ import { ResultListComparisonFormData, IndexOption } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
 import { SearchConfigForm } from '../search_configuration_form';
 import { QuerySetsComboBox } from './query_sets_combo_box';
-import { JudgmentsComboBox } from './judgments_combo_box';
+import { JudgmentSetsComboBox } from './judgment_sets_combo_box';
 
 interface UserBehaviorFormProps {
   formData: ResultListComparisonFormData;
@@ -20,16 +20,16 @@ export const UserBehaviorForm = ({
   const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
   const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
   const [k, setK] = useState<number>(10);
-  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
+  const [judgmentSetOptions, setJudgmentSetOptions] = useState<IndexOption[]>([]);
 
   const handleQuerySetsChange = (selectedOptions: any[]) => {
     setQuerySetOptions(selectedOptions || []);
     onChange('querySetId', selectedOptions?.[0]?.value);
   };
 
-  const handleJudgmentsChange = (selectedOptions: IndexOption[]) => {
-    setJudgmentOptions(selectedOptions || []);
-    onChange('judgmentList', selectedOptions.map((o) => o.value));
+  const handleJudgmentSetsChange = (selectedOptions: IndexOption[]) => {
+    setJudgmentSetOptions(selectedOptions || []);
+    onChange('judgmentSetList', selectedOptions.map((o) => o.value));
   };
 
   const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -76,9 +76,9 @@ export const UserBehaviorForm = ({
         />
       </EuiFlexItem>
       <EuiFlexItem>
-        <JudgmentsComboBox
-          selectedOptions={judgmentOptions}
-          onChange={handleJudgmentsChange}
+        <JudgmentSetsComboBox
+          selectedOptions={judgmentSetOptions}
+          onChange={handleJudgmentSetsChange}
           http={http}
         />
       </EuiFlexItem>

--- a/public/components/experiment_create/configuration/template_configuration.tsx
+++ b/public/components/experiment_create/configuration/template_configuration.tsx
@@ -16,7 +16,7 @@ export const TemplateConfiguration = ({
   history,
 }: TemplateConfigurationProps) => {
   /**
-   * Config Form will collect querySetId along with other experiment_type related fields to generate judgments.
+   * Config Form will collect querySetId along with other experiment_type related fields to generate judgment set.
    */
   const [configFormData, setConfigFormData] = useState<ConfigurationFormData | null>(null);
 

--- a/public/components/experiment_create/configuration/types.tsx
+++ b/public/components/experiment_create/configuration/types.tsx
@@ -26,7 +26,7 @@ export interface IndexOption {
 export interface ResultListComparisonFormData extends BaseFormData {}
 
 export interface UserBehaviorFormData extends BaseFormData {
-  judgmentList: string[];
+  judgmentSetList: string[];
 }
 
 export interface LLMFormData extends BaseFormData {

--- a/public/components/judgment_set_create/index.ts
+++ b/public/components/judgment_set_create/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { JudgmentListingWithRoute } from './judgment_listing';
+export { JudgmentSetCreateWithRouter } from './judgment_set_create';

--- a/public/components/judgment_set_create/judgment_set_create.tsx
+++ b/public/components/judgment_set_create/judgment_set_create.tsx
@@ -21,21 +21,21 @@ import React, { useCallback, useEffect, useState } from 'react';
 import { withRouter } from 'react-router-dom';
 import { ServiceEndpoints } from '../../../common';
 
-enum JudgmentType {
+enum JudgmentSetType {
   LLM = 'LLM_JUDGMENT',
   UBI = 'UBI_JUDGMENT',
 }
 
-interface JudgmentCreateProps {
+interface JudgmentSetCreateProps {
   http: any;
   notifications: any;
   history: any;
 }
 
-export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notifications, history }) => {
+export const JudgmentSetCreate: React.FC<JudgmentSetCreateProps> = ({ http, notifications, history }) => {
   const [name, setName] = useState('');
   const [nameError, setNameError] = useState('');
-  const [type, setType] = useState<JudgmentType>(JudgmentType.LLM);
+  const [type, setType] = useState<JudgmentSetType>(JudgmentSetType.LLM);
 
   // LLM specific states
   const [querySetOptions, setQuerySetOptions] = useState<Array<{ label: string; value: string }>>([]);
@@ -93,7 +93,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
 
   // Load data on component mount
   useEffect(() => {
-    if (type === JudgmentType.LLM) {
+    if (type === JudgmentSetType.LLM) {
       fetchQuerySets();
       fetchSearchConfigs();
     }
@@ -110,7 +110,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
       setNameError('');
     }
 
-    if (type === JudgmentType.LLM) {
+    if (type === JudgmentSetType.LLM) {
       if (selectedQuerySet.length === 0) {
         notifications.toasts.addDanger('Please select a query set');
         isValid = false;
@@ -129,13 +129,13 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
   };
 
   // Handle form submission
-  const createJudgment = useCallback(() => {
+  const createJudgmentSet = useCallback(() => {
     if (!validateForm()) {
       return;
     }
 
     const payload =
-      type === JudgmentType.LLM
+      type === JudgmentSetType.LLM
         ? {
             name,
             type,
@@ -154,11 +154,11 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
     http
       .put(ServiceEndpoints.Judgments, { body: JSON.stringify(payload) })
       .then(() => {
-        notifications.toasts.addSuccess('Judgment created successfully');
-        history.push('/judgment');
+        notifications.toasts.addSuccess('Judgment set created successfully');
+        history.push('/judgmentSet');
       })
       .catch((error: any) => {
-        notifications.toasts.addDanger(`Failed to create judgment: ${error.message}`);
+        notifications.toasts.addDanger(`Failed to create judgment set: ${error.message}`);
       });
   }, [
     validateForm,
@@ -176,32 +176,32 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
   ]);
 
   const handleCancel = () => {
-    history.push('/judgment');
+    history.push('/judgment_set');
   };
 
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
-        pageTitle="Judgment"
-        description="Configure a new judgment."
+        pageTitle="Judgment Set"
+        description="Configure a new judgment set."
         rightSideItems={[
           <EuiButtonEmpty
             onClick={handleCancel}
             iconType="cross"
             size="s"
-            data-test-subj="cancelJudgmentButton"
+            data-test-subj="cancelJudgmentSetButton"
           >
             Cancel
           </EuiButtonEmpty>,
           <EuiButton
-            onClick={createJudgment}
+            onClick={createJudgmentSet}
             fill
             size="s"
             iconType="check"
-            data-test-subj="createJudgmentButton"
+            data-test-subj="createJudgmentSetButton"
             color="primary"
           >
-            Create Judgment
+            Create Judgment Set
           </EuiButton>,
         ]}
       />
@@ -213,7 +213,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
               label="Name"
               isInvalid={nameError.length > 0}
               error={nameError}
-              helpText="A unique name for this judgment."
+              helpText="A unique name for this judgment set."
               fullWidth
             >
               <EuiFieldText
@@ -233,15 +233,15 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
             <EuiCompressedFormRow label="Type" fullWidth>
               <EuiSelect
                 options={[
-                  { value: JudgmentType.LLM, text: 'LLM Judgment' },
-                  { value: JudgmentType.UBI, text: 'UBI Judgment' },
+                  { value: JudgmentSetType.LLM, text: 'LLM Judgment' },
+                  { value: JudgmentSetType.UBI, text: 'UBI Judgment' },
                 ]}
                 value={type}
-                onChange={(e) => setType(e.target.value as JudgmentType)}
+                onChange={(e) => setType(e.target.value as JudgmentSetType)}
               />
             </EuiCompressedFormRow>
 
-            {type === JudgmentType.LLM ? (
+            {type === JudgmentSetType.LLM ? (
               <>
                 <EuiCompressedFormRow label="Query Set" fullWidth>
                   <EuiComboBox
@@ -313,4 +313,4 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
   );
 };
 
-export const JudgmentCreateWithRouter = withRouter(JudgmentCreate);
+export const JudgmentSetCreateWithRouter = withRouter(JudgmentSetCreate);

--- a/public/components/judgment_set_listing/index.ts
+++ b/public/components/judgment_set_listing/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { JudgmentView } from './judgment_view';
+export { JudgmentSetListingWithRoute } from './judgment_set_listing';

--- a/public/components/judgment_set_listing/judgment_set_listing.tsx
+++ b/public/components/judgment_set_listing/judgment_set_listing.tsx
@@ -24,37 +24,37 @@ import { useConfig } from '../../contexts/date_format_context';
 import { ServiceEndpoints } from '../../../common';
 import moment from 'moment';
 
-interface JudgmentListingProps extends RouteComponentProps {
+interface JudgmentSetListingProps extends RouteComponentProps {
   http: CoreStart['http'];
 }
 
-export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history }) => {
+export const JudgmentSetListing: React.FC<JudgmentSetListingProps> = ({ http, history }) => {
   const { dateFormat } = useConfig();
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 
   const [showDeleteModal, setShowDeleteModal] = useState(false);
-  const [judgmentToDelete, setJudgmentToDelete] = useState<any>(null);
+  const [judgmentSetToDelete, setJudgmentSetToDelete] = useState<any>(null);
   const [refreshKey, setRefreshKey] = useState(0);
 
   // Handle delete function
   const handleDelete = async () => {
     setIsLoading(true);
     try {
-      const response = await http.delete(`${ServiceEndpoints.Judgments}/${judgmentToDelete.id}`);
+      const response = await http.delete(`${ServiceEndpoints.Judgments}/${judgmentSetToDelete.id}`);
       console.log('Delete successful:', response);
 
       // Close modal and clear state
       setShowDeleteModal(false);
-      setJudgmentToDelete(null);
+      setJudgmentSetToDelete(null);
       setError(null);
 
       // Force table refresh
       setRefreshKey((prev) => prev + 1);
     } catch (err) {
-      setError('Failed to delete judgment');
+      setError('Failed to delete judgment set');
       setShowDeleteModal(false);
-      setJudgmentToDelete(null);
+      setJudgmentSetToDelete(null);
     } finally {
       setIsLoading(false);
     }
@@ -69,14 +69,14 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
       sortable: true,
       render: (
         name: string,
-        judgment: {
+        judgmentSet: {
           id: string;
         }
       ) => (
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `/judgment/view/${judgment.id}`)}
+            {...reactRouterNavigate(history, `/judgment_set/view/${judgmentSet.id}`)}
           >
             {name}
           </EuiButtonEmpty>
@@ -85,7 +85,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
     },
     {
       field: 'type',
-      name: 'Judgment Type',
+      name: 'Type',
       dataType: 'string',
       sortable: true,
     },
@@ -108,7 +108,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
           iconType="trash"
           color="danger"
           onClick={() => {
-            setJudgmentToDelete(item);
+            setJudgmentSetToDelete(item);
             setShowDeleteModal(true);
           }}
         />
@@ -116,7 +116,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
     },
   ];
 
-  const mapJudgmentFields = (obj: any) => {
+  const mapJudgmentSetFields = (obj: any) => {
     return {
       id: obj._source.id,
       name: obj._source.name,
@@ -126,12 +126,12 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
   };
 
   // Data fetching function
-  const findJudgments = async (search: any) => {
+  const findJudgmentSets = async (search: any) => {
     setIsLoading(true);
     setError(null);
     try {
       const response = await http.get(ServiceEndpoints.Judgments);
-      const list = response ? response.hits.hits.map(mapJudgmentFields) : [];
+      const list = response ? response.hits.hits.map(mapJudgmentSetFields) : [];
       // TODO: too many reissued requests on search
       const filteredList = search
         ? list.filter((item) => item.name.toLowerCase().includes(search.toLowerCase()))
@@ -141,7 +141,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
         hits: filteredList,
       };
     } catch (err) {
-      setError('Failed to load judgments');
+      setError('Failed to load judgment sets');
       return {
         total: 0,
         hits: [],
@@ -153,8 +153,8 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
-        pageTitle="Judgments"
-        description="View and manage your existing judgments. Click on a judgment name to view details."
+        pageTitle="Judgment Sets"
+        description="View and manage your existing judgment sets. Click on a name to view details."
         rightSideItems={[
           <EuiButtonEmpty
             iconType="arrowLeft"
@@ -175,11 +175,11 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
         ) : (
           <TableListView
             key={refreshKey}
-            headingId="judgmentListingHeading"
-            entityName="Judgment"
-            entityNamePlural="Judgments"
+            headingId="judgmentSetListingHeading"
+            entityName="JudgmentSet"
+            entityNamePlural="JudgmentSets"
             tableColumns={tableColumns}
-            findItems={findJudgments}
+            findItems={findJudgmentSets}
             loading={isLoading}
             pagination={{
               initialPageSize: 10,
@@ -188,7 +188,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
             search={{
               box: {
                 incremental: true,
-                placeholder: 'Search judgments...',
+                placeholder: 'Search judgment sets...',
                 schema: true,
               },
             }}
@@ -203,20 +203,20 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
       </EuiFlexItem>
 
       {/* Delete Confirmation Modal */}
-      {showDeleteModal && judgmentToDelete && (
+      {showDeleteModal && judgmentSetToDelete && (
         <DeleteModal
           onClose={() => {
             setShowDeleteModal(false);
-            setJudgmentToDelete(null);
+            setJudgmentSetToDelete(null);
           }}
           onConfirm={handleDelete}
-          itemName={judgmentToDelete.name}
+          itemName={judgmentSetToDelete.name}
         />
       )}
     </EuiPageTemplate>
   );
 };
 
-export const JudgmentListingWithRoute = withRouter(JudgmentListing);
+export const JudgmentSetListingWithRoute = withRouter(JudgmentSetListing);
 
-export default JudgmentListingWithRoute;
+export default JudgmentSetListingWithRoute;

--- a/public/components/judgment_set_view/index.ts
+++ b/public/components/judgment_set_view/index.ts
@@ -3,4 +3,4 @@
  * SPDX-License-Identifier: Apache-2.0
  */
 
-export { JudgmentCreateWithRouter } from './judgment_create';
+export { JudgmentSetView } from './judgment_set_view';

--- a/public/components/judgment_set_view/judgment_set_view.tsx
+++ b/public/components/judgment_set_view/judgment_set_view.tsx
@@ -18,16 +18,16 @@ import {
 import { CoreStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../common';
 
-interface JudgmentViewProps extends RouteComponentProps<{ id: string }> {
+interface JudgmentSetViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
 }
 
-export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
-  const [judgment, setJudgment] = useState<any | null>(null);
+export const JudgmentSetView: React.FC<JudgmentSetViewProps> = ({ http, id }) => {
+  const [judgmentSet, setJudgmentSet] = useState<any | null>(null);
   const [loading, setLoading] = useState<boolean>(true);
   const [error, setError] = useState<string | null>(null);
 
-  const JudgmentViewPane: React.FC = () => {
+  const JudgmentSetViewPane: React.FC = () => {
     const formatJson = (json: string) => {
       try {
         return JSON.stringify(JSON.parse(json), null, 2);
@@ -39,17 +39,17 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
     return (
       <EuiForm>
         <EuiFormRow
-          label="Judgment Name"
+          label="Judgment Set Name"
           fullWidth
         >
-          <EuiText>{judgment.name}</EuiText>
+          <EuiText>{judgmentSet.name}</EuiText>
         </EuiFormRow>
 
         <EuiFormRow
           label="Type"
           fullWidth
         >
-          <EuiText>{judgment.type}</EuiText>
+          <EuiText>{judgmentSet.type}</EuiText>
         </EuiFormRow>
 
         <EuiFormRow
@@ -57,7 +57,7 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
           fullWidth
         >
           <EuiText>
-            {Object.entries(judgment.metadata).map(([key, value]) => (
+            {Object.entries(judgmentSet.metadata).map(([key, value]) => (
               <p key={key}>
                 <strong>{key}:</strong> {JSON.stringify(value)}
               </p>
@@ -66,7 +66,7 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
         </EuiFormRow>
 
         <EuiFormRow
-          label="JudgmentScores"
+          label="JudgmentSetScores"
           fullWidth
         >
           <EuiPanel
@@ -75,7 +75,7 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
             style={{ maxHeight: '200px', overflow: 'auto' }}
           >
             <EuiCodeBlock language="json" paddingSize="s" isCopyable>
-              {JSON.stringify(judgment.judgmentScores, null, 2)}
+              {JSON.stringify(judgmentSet.judgmentScores, null, 2)}
             </EuiCodeBlock>
           </EuiPanel>
         </EuiFormRow>
@@ -86,7 +86,7 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
   };
 
   useEffect(() => {
-    const fetchJudgment = async () => {
+    const fetchJudgmentSet = async () => {
       try {
         setLoading(true);
         const response = await http.get(ServiceEndpoints.Judgments);
@@ -94,12 +94,12 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
         const filteredList = list.filter((item: any) => item.id === id);
 
         if (filteredList.length > 0) {
-          setJudgment(filteredList[0]);
+          setJudgmentSet(filteredList[0]);
         } else {
-          setError('No matching judgment found');
+          setError('No matching judgment set found');
         }
       } catch (err) {
-        setError('Error loading judgment data');
+        setError('Error loading judgment set data');
         // eslint-disable-next-line no-console
         console.error(err);
       } finally {
@@ -107,11 +107,11 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
       }
     };
 
-    fetchJudgment();
+    fetchJudgmentSet();
   }, [http, id]);
 
   if (loading) {
-    return <div>Loading judgment data...</div>;
+    return <div>Loading judgment set data...</div>;
   }
 
   if (error) {
@@ -121,15 +121,15 @@ export const JudgmentView: React.FC<JudgmentViewProps> = ({ http, id }) => {
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
-        pageTitle="Judgment Details"
-        description="View the details of your judgment"
+        pageTitle="Judgment Set Details"
+        description="View the details of your judgment set"
       />
       <EuiSpacer size="l" />
       <EuiPanel hasBorder={true}>
-        <JudgmentViewPane />
+        <JudgmentSetViewPane />
       </EuiPanel>
     </EuiPageTemplate>
   );
 };
 
-export default JudgmentView;
+export default JudgmentSetView;

--- a/public/components/resource_management_home/get_started_accordion.tsx
+++ b/public/components/resource_management_home/get_started_accordion.tsx
@@ -86,7 +86,7 @@ export function GetStartedAccordion(props: GetStartedAccordionProps) {
               }
             >
               <EuiText>
-                Document-based judgement scores will be collect and aggregated into evaluation metrics.
+                Document-based judgment scores will be collect and aggregated into evaluation metrics.
               </EuiText>
             </EuiCard>
           </EuiFlexItem>

--- a/public/components/resource_management_home/resource_management_tabs.tsx
+++ b/public/components/resource_management_home/resource_management_tabs.tsx
@@ -17,9 +17,9 @@ import { TemplateCards } from '../experiment_create/template_card/template_cards
 import ExperimentViewWithRouter from '../experiment_view/experiment_view';
 import ExperimentListingWithRoute from '../experiment_listing/experiment_listing';
 import { useOpenSearchDashboards } from '../../../../../src/plugins/opensearch_dashboards_react/public';
-import { JudgmentCreateWithRouter } from '../judgment_create';
-import { JudgmentListingWithRoute } from '../judgment_listing';
-import { JudgmentView } from '../judgment_view';
+import { JudgmentSetCreateWithRouter } from '../judgment_set_create';
+import { JudgmentSetListingWithRoute } from '../judgment_set_listing';
+import { JudgmentSetView } from '../judgment_set_view';
 
 const TAB_STYLES = {
   mainTabs: {
@@ -67,7 +67,7 @@ export const ResourceManagementTabs = ({
     { id: 'experiment', name: 'Experiment' },
     { id: 'querySet', name: 'Query Set' },
     { id: 'searchConfiguration', name: 'Search Configuration' },
-    { id: 'judgment', name: 'Judgment' },
+    { id: 'judgmentSet', name: 'Judgment Set' },
   ];
 
   const renderSubTabs = (tabKey: string, tabs: Array<{ id: string; label: string }>) => (
@@ -162,23 +162,23 @@ export const ResourceManagementTabs = ({
           </>
         );
 
-      case 'judgment':
+      case 'judgmentSet':
         return (
           <>
-            {renderSubTabs('judgment', [
-              { id: 'list', label: 'Manage Judgments' },
-              { id: 'create', label: 'Create a Judgment' },
+            {renderSubTabs('judgmentSet', [
+              { id: 'list', label: 'Manage Judgment Sets' },
+              { id: 'create', label: 'Create a Judgment Set' },
             ])}
             <EuiSpacer size="m" />
             <EuiPanel>
               {selectedSubTabs === 'list' && entityAction != 'view' ? (
-                <JudgmentListingWithRoute http={http} />
+                <JudgmentSetListingWithRoute http={http} />
               ) : (
                 <></>
               )}
-              {entityAction === 'view' ? <JudgmentView http={http} id={entityId}/> : <></>}
+              {entityAction === 'view' ? <JudgmentSetView http={http} id={entityId}/> : <></>}
               {selectedSubTabs === 'create' ? (
-                <JudgmentCreateWithRouter http={http} notifications={notifications} history={history}/>
+                <JudgmentSetCreateWithRouter http={http} notifications={notifications} history={history}/>
               ) : (
                 <></>
               )}

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -104,7 +104,7 @@ export type EvaluationExperiment =
   (ExperimentBase & {
     type: "UBI_EVALUATION";
     searchConfigurationId: string;
-    judgmentId: string;
+    judgmentSetId: string;
   })
 
 export const printType = (type: string) => {
@@ -259,8 +259,8 @@ export const toExperiment = (source: any): ParseResult<Experiment> => {
     if (source.searchConfigurationList.length < 1) {
       return parseError("Missing search configuration for UBI evaluation (searchConfigurationList).");
     }
-    if (!source.judgmentList || source.judgmentList.length < 1) {
-      return parseError("Missing judgment for UBI evaluation (judgmentList).");
+    if (!source.judgmentSetList || source.judgmentSetList.length < 1) {
+      return parseError("Missing judgment set for UBI evaluation (judgmentSetList).");
     }
     return {
       success: true,
@@ -272,7 +272,7 @@ export const toExperiment = (source: any): ParseResult<Experiment> => {
         querySetId: source.querySetId,
         timestamp: source.timestamp,
         searchConfigurationId: source.searchConfigurationList[0],
-        judgmentId: source.judgmentList[0],
+        judgmentSetId: source.judgmentSetList[0],
         size,
       },
     };


### PR DESCRIPTION
### Description
Per the UI review, we want to refer to *Judgment Sets*, as they are a group of Judgment's.   This PR renames in the front end all the source files and names.   

I'd like to get this reviewed and merged, and then would be willing to see how we named things in the backend.

I left the `ServiceEndpoints.Judgments` alone, though would I think want to change that to `ServiceEndpoints.JudgmentSets` as well?

### Issues Resolved
n/a, but see https://docs.google.com/document/d/1l05HSSlGBIcb1oU1LT3b06KVyHYqOteZlbkFIqHhHv8/edit?tab=t.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
