### PR TITLE
Lighter touch tweaking of labels for judgment: judgments and judgement lists

### DIFF
--- a/public/components/experiment_create/configuration/form/judgments_combo_box.tsx
+++ b/public/components/experiment_create/configuration/form/judgments_combo_box.tsx
@@ -41,7 +41,7 @@ export const JudgmentsComboBox = ({
   return (
     <EuiFormRow label="Judgments">
       <EuiComboBox
-        placeholder={isLoading ? 'Loading...' : 'Select judgments'}
+        placeholder={isLoading ? 'Loading...' : 'Select judgment list'}
         options={judgmentOptions}
         selectedOptions={selectedOptions}
         onChange={onChange}
@@ -54,4 +54,4 @@ export const JudgmentsComboBox = ({
       />
     </EuiFormRow>
   );
-}; 
+};

--- a/public/components/judgment_create/judgment_create.tsx
+++ b/public/components/judgment_create/judgment_create.tsx
@@ -182,8 +182,8 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
   return (
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
-        pageTitle="Judgment"
-        description="Configure a new judgment."
+        pageTitle="Judgment List"
+        description="Configure a new judgment list."
         rightSideItems={[
           <EuiButtonEmpty
             onClick={handleCancel}
@@ -201,7 +201,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
             data-test-subj="createJudgmentButton"
             color="primary"
           >
-            Create Judgment
+            Create Judgment List
           </EuiButton>,
         ]}
       />
@@ -213,7 +213,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
               label="Name"
               isInvalid={nameError.length > 0}
               error={nameError}
-              helpText="A unique name for this judgment."
+              helpText="A unique name for these judgements."
               fullWidth
             >
               <EuiFieldText

--- a/public/components/judgment_listing/judgment_listing.tsx
+++ b/public/components/judgment_listing/judgment_listing.tsx
@@ -154,7 +154,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
         pageTitle="Judgments"
-        description="View and manage your existing judgments. Click on a judgment name to view details."
+        description="View and manage your existing judgments. Click on a judgment list name to view details."
         rightSideItems={[
           <EuiButtonEmpty
             iconType="arrowLeft"

--- a/public/components/resource_management_home/resource_management_tabs.tsx
+++ b/public/components/resource_management_home/resource_management_tabs.tsx
@@ -67,7 +67,7 @@ export const ResourceManagementTabs = ({
     { id: 'experiment', name: 'Experiment' },
     { id: 'querySet', name: 'Query Set' },
     { id: 'searchConfiguration', name: 'Search Configuration' },
-    { id: 'judgment', name: 'Judgment' },
+    { id: 'judgment', name: 'Judgments' },
   ];
 
   const renderSubTabs = (tabKey: string, tabs: Array<{ id: string; label: string }>) => (
@@ -167,7 +167,7 @@ export const ResourceManagementTabs = ({
           <>
             {renderSubTabs('judgment', [
               { id: 'list', label: 'Manage Judgments' },
-              { id: 'create', label: 'Create a Judgment' },
+              { id: 'create', label: 'Create a Judgment List' },
             ])}
             <EuiSpacer size="m" />
             <EuiPanel>


### PR DESCRIPTION
### Description
This is an alternative to https://github.com/o19s/dashboards-search-relevance/pull/38 where we took a hard rule and called Judgements "Judgement Sets" (similiar to how queries are always "Query Sets").   

Based on feedback from @wrigleyDan in this PR I am trying to make more natural language titles.  So using the term "Judgements" and "Judgement Lists" as appropriate.....

### Issues Resolved
n/a, but see https://docs.google.com/document/d/1l05HSSlGBIcb1oU1LT3b06KVyHYqOteZlbkFIqHhHv8/edit?tab=t.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
