### PR TITLE
Update how we define an optional parameter to meet modern OUI standard

### DIFF
--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -211,9 +211,11 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
           </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiCompressedFormRow            
+          <EuiCompressedFormRow
             label={
+              <p>
                 Pipeline <i> - optional </i>
+              </p>
             }
             fullWidth
           >

--- a/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
+++ b/public/components/query_compare/search_result/search_components/search_configs/search_config.tsx
@@ -211,7 +211,12 @@ export const SearchConfig: FunctionComponent<SearchConfigProps> = ({
           </EuiCompressedFormRow>
         </EuiFlexItem>
         <EuiFlexItem>
-          <EuiCompressedFormRow fullWidth label="Pipeline-optional">
+          <EuiCompressedFormRow            
+            label={
+                Pipeline <i> - optional </i>
+            }
+            fullWidth
+          >
             <EuiCompressedComboBox
               placeholder=""
               singleSelection={{ asPlainText: true }}

--- a/public/components/search_config_create/search_configuration_form.tsx
+++ b/public/components/search_config_create/search_configuration_form.tsx
@@ -142,7 +142,15 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
       />
     </EuiFormRow>
 
-    <EuiFormRow label="Search Pipeline" helpText="Define the search pipeline to be used." fullWidth>
+    <EuiFormRow
+      label={
+        <p>
+          Search Pipeline <i> - optional </i>
+        </p>
+      }
+      helpText="Define the search pipeline to be used." 
+      fullWidth
+    >
       <EuiComboBox
         placeholder="Select a search pipeline"
         options={pipelineOptions}
@@ -159,7 +167,15 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
       />
     </EuiFormRow>
 
-    <EuiFormRow label="Search Template" helpText="Define the search template." fullWidth>
+    <EuiFormRow
+      label={
+        <p>
+          Search Template <i> - optional </i>
+        </p>
+      }
+      helpText="Define the search template."
+      fullWidth
+    >
       <EuiFieldText
         placeholder="Enter search template"
         value={searchTemplate}


### PR DESCRIPTION
### Description
Use the standard way of communicating a field is optional.

### Issues Resolved
n/a however see https://docs.google.com/document/d/1l05HSSlGBIcb1oU1LT3b06KVyHYqOteZlbkFIqHhHv8/edit?tab=t.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
