### PR TITLE
Make the run experimient/cancel,back buttons work the same as other screens

### DIFF
--- a/public/components/experiment_create/configuration/configuration_action.tsx
+++ b/public/components/experiment_create/configuration/configuration_action.tsx
@@ -1,32 +1,23 @@
+/*
+ * Copyright OpenSearch Contributors
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
 import React from 'react';
-import {
-  EuiFlexGroup,
-  EuiFlexItem,
-  EuiButton,
-  EuiButtonEmpty,
-} from '@elastic/eui';
+import { EuiFlexGroup, EuiFlexItem, EuiButton, EuiButtonEmpty } from '@elastic/eui';
 import { ConfigurationActionsProps } from './types';
 
-export const ConfigurationActions = ({
-                                       onBack,
-                                       onClose,
-                                       onNext,
-                                     }: ConfigurationActionsProps) => (
+export const ConfigurationActions = ({ onBack, onClose, onNext }: ConfigurationActionsProps) => (
   <EuiFlexGroup justifyContent="flexEnd">
-    <EuiFlexItem grow={false}>
-      <EuiButtonEmpty onClick={onBack}>
-        Back to Experiments
-      </EuiButtonEmpty>
-    </EuiFlexItem>
-    <EuiFlexItem grow={false}>
-      <EuiButton fill onClick={onBack}>
-        Cancel
-      </EuiButton>
-    </EuiFlexItem>
     <EuiFlexItem grow={false}>
       <EuiButton fill iconType="play" onClick={onNext}>
         Start Evaluation
       </EuiButton>
+    </EuiFlexItem>
+    <EuiFlexItem grow={false}>
+      <EuiButtonEmpty onClick={onBack} iconType="cross" size="s">
+        Cancel
+      </EuiButtonEmpty>
     </EuiFlexItem>
   </EuiFlexGroup>
 );


### PR DESCRIPTION


### Description
We had an extra "back to experiments" link, that wasn't used in any other resources page like judgments or search configurations.  Plus the button was different.  This brings the buttons into the same style.

### Issues Resolved
N/a, but see https://docs.google.com/document/d/1l05HSSlGBIcb1oU1LT3b06KVyHYqOteZlbkFIqHhHv8/edit?tab=t.0

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
