### PR TITLE
Easier to parameterize colors and match Venn diagram colors

### DIFF
--- a/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
@@ -6,7 +6,7 @@ interface ConnectionLinesProps {
   result2: any[];
   result1ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
   result2ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
-  getStatusColor: (item: any, resultNum: number) => string;
+  lineColors: { [key: string]: string };
 }
 
 export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
@@ -15,7 +15,7 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
   result2,
   result1ItemsRef,
   result2ItemsRef,
-  getStatusColor,
+  lineColors,
 }) => {
   return (
     <svg width="100%" height="420" style={{ overflow: 'visible' }} className="absolute top-0 left-0" id="connection-lines">
@@ -31,7 +31,7 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
         
         // Only draw line if both elements exist
         if (!r1El || !r2El) return null;
-        
+
         try {
           // Calculate positions for connecting line
           const r1Rect = r1El.getBoundingClientRect();
@@ -44,9 +44,13 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
           const y1 = r1Rect.top - svgRect.top + r1Rect.height / 2;
           const y2 = r2Rect.top - svgRect.top + r2Rect.height / 2;
           
-          // Get color using the provided function
-          const lineColor = getStatusColor(r1Item, 1);
-          
+          let lineColor = lineColors.unchanged;
+          if (r1Item.rank < r2Match.rank) {
+            lineColor = lineColors.decreased;
+          } else if (r1Item.rank > r2Match.rank) {
+            lineColor = lineColors.increased;
+          }
+
           return (
             <line 
               key={`line-${r1Item._id}`}

--- a/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
@@ -44,11 +44,11 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
           const y1 = r1Rect.top - svgRect.top + r1Rect.height / 2;
           const y2 = r2Rect.top - svgRect.top + r2Rect.height / 2;
           
-          let lineColor = lineColors.unchanged;
+          let lineProps = lineColors.unchanged;
           if (r1Item.rank < r2Match.rank) {
-            lineColor = lineColors.decreased;
+            lineProps = lineColors.decreased;
           } else if (r1Item.rank > r2Match.rank) {
-            lineColor = lineColors.increased;
+            lineProps = lineColors.increased;
           }
 
           return (
@@ -58,8 +58,7 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
               y1={y1} 
               x2="100%" 
               y2={y2} 
-              stroke={lineColor} 
-              strokeWidth="4"
+              {...lineProps}
             />
           );
         } catch (error) {

--- a/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/connection_lines.tsx
@@ -6,6 +6,7 @@ interface ConnectionLinesProps {
   result2: any[];
   result1ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
   result2ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
+  getStatusColor: (item: any, resultNum: number) => string;
 }
 
 export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
@@ -14,6 +15,7 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
   result2,
   result1ItemsRef,
   result2ItemsRef,
+  getStatusColor,
 }) => {
   return (
     <svg width="100%" height="420" style={{ overflow: 'visible' }} className="absolute top-0 left-0" id="connection-lines">
@@ -22,16 +24,6 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
         // Find if this item exists in result2
         const r2Match = result2.find(r2 => r2._id === r1Item._id);
         if (!r2Match) return null; // Skip if no match
-        
-        // Line color based on rank comparison
-        let lineColor;
-        if (r1Item.rank === r2Match.rank) {
-          lineColor = "#93C5FD"; // Blue for unchanged
-        } else if (r1Item.rank < r2Match.rank) {
-          lineColor = "#FCA5A5"; // Red for dropped
-        } else {
-          lineColor = "#86EFAC"; // Green for improved
-        }
         
         // Get elements by ref to ensure we have their positions
         const r1El = result1ItemsRef.current[r1Item._id];
@@ -51,6 +43,9 @@ export const ConnectionLines: React.FC<ConnectionLinesProps> = ({
           // Calculate relative positions within the SVG
           const y1 = r1Rect.top - svgRect.top + r1Rect.height / 2;
           const y2 = r2Rect.top - svgRect.top + r2Rect.height / 2;
+          
+          // Get color using the provided function
+          const lineColor = getStatusColor(r1Item, 1);
           
           return (
             <line 

--- a/public/components/query_compare/search_result/visual_comparison/item_detail_hover_pane.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/item_detail_hover_pane.tsx
@@ -91,6 +91,16 @@ export const ItemDetailHoverPane: React.FC<ItemDetailHoverPaneProps> = ({
       onMouseEnter={onMouseEnter}
       onMouseLeave={onMouseLeave}
     >
+      <div className="flex justify-between items-start mb-2">
+        <h3 className="text-lg font-semibold">Item Details</h3>
+        <button 
+          onClick={onMouseLeave}
+          className="text-gray-500 hover:text-gray-700"
+        >
+          ✕
+        </button>
+      </div>
+
       {imageFieldName && item[imageFieldName] && item[imageFieldName].match(/\.(jpg|jpeg|png|gif|svg|webp)($|\?)/i) ? (
         <>
           <div className="flex items-center mb-2">

--- a/public/components/query_compare/search_result/visual_comparison/result_items.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/result_items.tsx
@@ -6,8 +6,7 @@ interface ResultItemsProps {
   imageFieldName?: string;
   displayField: string;
   getStatusColor: (item: any, resultNum: number) => string;
-  handleItemMouseEnter: (item: any, event: React.MouseEvent) => void;
-  handleItemMouseLeave: () => void;
+  handleItemClick: (item: any, event: React.MouseEvent) => void;
   result1ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
   result2ItemsRef: React.MutableRefObject<{ [key: string]: HTMLDivElement }>;
 }
@@ -18,8 +17,7 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
   imageFieldName,
   displayField,
   getStatusColor,
-  handleItemMouseEnter,
-  handleItemMouseLeave,
+  handleItemClick,
   result1ItemsRef,
   result2ItemsRef,
 }) => {
@@ -34,9 +32,8 @@ export const ResultItems: React.FC<ResultItemsProps> = ({
               (resultNum === 1 ? result1ItemsRef : result2ItemsRef).current[item._id] = el;
             }
           }}
-          className={`flex ${resultNum === 1 ? 'flex-row-reverse' : ''} items-center mb-2 hover:bg-gray-100 p-1 rounded`}
-          onMouseEnter={(event) => handleItemMouseEnter(item, event)}
-          onMouseLeave={handleItemMouseLeave}
+          className={`flex ${resultNum === 1 ? 'flex-row-reverse' : ''} items-center mb-2 hover:bg-gray-100 p-1 rounded cursor-pointer`}
+          onClick={(event) => handleItemClick(item, event)}
         >
           <div className={`w-8 h-8 rounded-full ${getStatusColor(item, resultNum)} flex items-center justify-center font-bold ${resultNum === 1 ? 'ml-2' : 'mr-2'} flex-shrink-0`}>
             {item.rank}

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
@@ -399,6 +399,7 @@
 :root {
   --yellow-custom: 254, 245, 150;
   --purple-custom: 233, 213, 255;
+  --gray-custom: 240, 242, 244;
 }
 
 .bg-yellow-custom {
@@ -423,6 +424,11 @@
 
 .bg-purple-custom {
   background-color: rgb(var(--purple-custom));
+}
+
+.rank-no-change {
+  background-color: rgb(var(--gray-custom));
+  // border: 1px solid #000;
 }
 
 .bg-red-300 {
@@ -593,7 +599,7 @@ svg line {
   position: absolute;
   left: 50%;
   transform: translateX(-50%);
-  background-color: rgba(219, 234, 254, 0.7); /* bg-blue-100 with opacity */
+  // background-color: rgba(219, 234, 254, 0.7); /* bg-blue-100 with opacity */
   width: 17%;
   height: 6rem; /* h-32 */
   border-radius: 1rem; /* rounded-lg */

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
@@ -577,7 +577,7 @@ svg line {
   position: absolute;
   left: 50%;
   transform: translateX(-84%);
-  background-color: rgba(var(--yellow-custom), 0.9);
+  // background-color: rgba(var(--yellow-custom), 0.9);
   width: 50%;
   height: 6rem; /* h-32 */
   border-radius: 1rem; /* rounded-lg */
@@ -610,7 +610,7 @@ svg line {
   position: absolute;
   left: 50%;
   transform: translateX(-16%);
-  background-color: rgba(var(--purple-custom), 0.9);
+  // background-color: rgba(var(--purple-custom), 0.9);
   width: 50%;
   height: 6rem; /* h-32 */
   border-radius: 1rem; /* rounded-lg */

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.scss
@@ -396,6 +396,15 @@
   background-color: #fefce8;
 }
 
+:root {
+  --yellow-custom: 254, 245, 150;
+  --purple-custom: 233, 213, 255;
+}
+
+.bg-yellow-custom {
+  background-color: rgb(var(--yellow-custom));
+}
+
 .bg-yellow-300 {
   background-color: #fcd34d;
 }
@@ -410,6 +419,10 @@
 
 .bg-purple-300 {
   background-color: #c4b5fd;
+}
+
+.bg-purple-custom {
+  background-color: rgb(var(--purple-custom));
 }
 
 .bg-red-300 {
@@ -564,7 +577,7 @@ svg line {
   position: absolute;
   left: 50%;
   transform: translateX(-84%);
-  background-color: rgba(254, 249, 195, 0.9); /* bg-yellow-100 with opacity */
+  background-color: rgba(var(--yellow-custom), 0.9);
   width: 50%;
   height: 6rem; /* h-32 */
   border-radius: 1rem; /* rounded-lg */
@@ -597,7 +610,7 @@ svg line {
   position: absolute;
   left: 50%;
   transform: translateX(-16%);
-  background-color: rgba(233, 213, 255, 0.3); /* bg-purple-100 with opacity */
+  background-color: rgba(var(--purple-custom), 0.9);
   width: 50%;
   height: 6rem; /* h-32 */
   border-radius: 1rem; /* rounded-lg */

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect, useRef } from 'react';
-import { EuiPanel, EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent, EuiSuperSelect, EuiFormRow } from '@elastic/eui';
+import { EuiPanel, EuiEmptyPrompt, EuiPage, EuiPageBody, EuiPageContent, EuiSuperSelect, EuiFormRow, EuiAccordion } from '@elastic/eui';
 
 import './visual_comparison.scss';
 import { ItemDetailHoverPane } from './item_detail_hover_pane';
@@ -407,25 +407,6 @@ export const VisualComparison = ({
         <EuiPageContent>
           <h3 className="text-lg font-semibold mb-2">Results for query: <em>{queryText}</em></h3>
 
-          {/* Style selector dropdown */}
-          <div className="mb-4">
-            <EuiFormRow label="Visualization Style:" id="styleSelectorForm">
-              <EuiSuperSelect
-                id="style-selector"
-                options={[
-                  { value: 'default', inputDisplay: 'Default Style', dropdownDisplay: 'Default Style' },
-                  { value: 'simpler', inputDisplay: 'Ranking Change Color Coding', dropdownDisplay: 'Ranking Change Color Coding' },
-                  { value: 'simpler2', inputDisplay: 'Ranking Change Color Coding 2', dropdownDisplay: 'Ranking Change Color Coding 2' },
-                  { value: 'twoColor', inputDisplay: 'Venn Diagram Color Coding', dropdownDisplay: 'Venn Diagram Color Coding' }
-                ]}
-                valueOfSelected={selectedStyle}
-                onChange={(value) => setSelectedStyle(value)}
-                fullWidth
-                hasDividers
-              />
-            </EuiFormRow>
-          </div>
-
           {/* Field selector dropdown */}
           <div className="mb-4">
             <EuiFormRow label="Display Field:" id="fieldSelectorForm">
@@ -537,6 +518,31 @@ export const VisualComparison = ({
                 <div className={`w-4 h-4 ${statusClassName.inResult2} mr-1`}></div> Only in {resultText2}
               </div>
             )}
+          </div>
+
+          {/* Style selector dropdown */}
+          <div className="mt-4">
+            <EuiAccordion
+              id="styleSelectorAccordion"
+              buttonContent={<span className="text-xs">Visualization Style Options</span>}
+              paddingSize="m"
+            >
+              <EuiFormRow label="Visualization Style:" id="styleSelectorForm">
+                <EuiSuperSelect
+                  id="style-selector"
+                  options={[
+                    { value: 'default', inputDisplay: 'Default Style', dropdownDisplay: 'Default Style' },
+                    { value: 'simpler', inputDisplay: 'Ranking Change Color Coding', dropdownDisplay: 'Ranking Change Color Coding' },
+                    { value: 'simpler2', inputDisplay: 'Ranking Change Color Coding 2', dropdownDisplay: 'Ranking Change Color Coding 2' },
+                    { value: 'twoColor', inputDisplay: 'Venn Diagram Color Coding', dropdownDisplay: 'Venn Diagram Color Coding' }
+                  ]}
+                  valueOfSelected={selectedStyle}
+                  onChange={(value) => setSelectedStyle(value)}
+                  fullWidth
+                  hasDividers
+                />
+              </EuiFormRow>
+            </EuiAccordion>
           </div>
 
           {/* Item Details Tooltip on Click */}

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -26,7 +26,7 @@ export const convertFromSearchResult = (searchResult) => {
   }));
 }
 
-export const defaultStyle = {
+export const defaultStyleConfig = {
   lineColors: {
     unchanged: { stroke: "#93C5FD", strokeWidth: 4 },
     increased: { stroke: "#86EFAC", strokeWidth: 4 },
@@ -47,7 +47,7 @@ export const defaultStyle = {
   hideLegend: [],
 }
 
-export const simplerVennDiagramStyle = {
+export const rankingChangeStyleConfig = {
   lineColors: {
     unchanged: { stroke: "#93C5FD", strokeWidth: 4 },
     increased: { stroke: "#86EFAC", strokeWidth: 4 },
@@ -68,7 +68,7 @@ export const simplerVennDiagramStyle = {
   hideLegend: ['inResult1', 'inResult2'],
 }
 
-export const twoColorScheme = {
+export const vennDiagramStyleConfig = {
   lineColors: {
     unchanged: { stroke: "black", strokeWidth: 2 },
     increased: { stroke: "black", strokeWidth: 2 },
@@ -103,11 +103,11 @@ export const VisualComparison = ({
   const getCurrentStyle = () => {
     switch (selectedStyle) {
       case 'simpler':
-        return simplerVennDiagramStyle;
+        return rankingChangeStyleConfig;
       case 'twoColor':
-        return twoColorScheme;
+        return vennDiagramStyleConfig;
       default:
-        return defaultStyle;
+        return defaultStyleConfig;
     }
   };
 
@@ -400,8 +400,8 @@ export const VisualComparison = ({
                 id="style-selector"
                 options={[
                   { value: 'default', inputDisplay: 'Default Style', dropdownDisplay: 'Default Style' },
-                  { value: 'simpler', inputDisplay: 'Simpler Style', dropdownDisplay: 'Simpler Style' },
-                  { value: 'twoColor', inputDisplay: 'Two Color Style', dropdownDisplay: 'Two Color Style' }
+                  { value: 'simpler', inputDisplay: 'Ranking Change Color Coding', dropdownDisplay: 'Ranking Change Color Coding' },
+                  { value: 'twoColor', inputDisplay: 'Venn Diagram Color Coding', dropdownDisplay: 'Venn Diagram Color Coding' }
                 ]}
                 valueOfSelected={selectedStyle}
                 onChange={(value) => setSelectedStyle(value)}
@@ -498,7 +498,7 @@ export const VisualComparison = ({
             </div>
           </div>
 
-          <div className="mt-4 flex gap-4 text-sm">
+          <div className="mt-4 flex gap-4 text-sm justify-center">
             { !hideLegend.includes('unchanged') && (
               <div className="flex items-center">
                 <div className={`w-4 h-4 ${statusClassName.unchanged} mr-1`}></div> Unchanged rank

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -146,8 +146,7 @@ export const VisualComparison = ({
   ]);
 
   // State for hover item details
-  const [hoveredItem, setHoveredItem] = useState(null);
-  const hoverTimeoutRef = useRef(null);
+  const [selectedItem, setSelectedItem] = useState(null);
   const [mousePosition, setMousePosition] = useState(null);
 
   // Refs for elements
@@ -373,23 +372,15 @@ export const VisualComparison = ({
 
   };
 
-  // Function to handle hover for item details
-  const handleItemMouseEnter = (item, event) => {
-    // Clear any existing timeout to prevent flickering
-    if (hoverTimeoutRef.current) {
-      clearTimeout(hoverTimeoutRef.current);
+  // Function to handle click for item details
+  const handleItemClick = (item, event) => {
+    // Toggle the selected item - if clicking the same item, close it
+    if (selectedItem && selectedItem._id === item._id) {
+      setSelectedItem(null);
+    } else {
+      setSelectedItem(item);
+      setMousePosition({ x: event.clientX, y: event.clientY });
     }
-
-    // Set the hovered item and mouse position
-    setHoveredItem(item);
-    setMousePosition({ x: event.clientX, y: event.clientY });
-  };
-
-  const handleItemMouseLeave = () => {
-    // Add a small delay before hiding the tooltip to prevent flickering
-    hoverTimeoutRef.current = setTimeout(() => {
-      setHoveredItem(null);
-    }, 100);
   };
 
   // Initial state (empty prompt) when no valid results
@@ -483,8 +474,7 @@ export const VisualComparison = ({
                   imageFieldName={imageFieldName}
                   displayField={displayField}
                   getStatusColor={getStatusColor}
-                  handleItemMouseEnter={handleItemMouseEnter}
-                  handleItemMouseLeave={handleItemMouseLeave}
+                  handleItemClick={handleItemClick}
                   result1ItemsRef={result1ItemsRef}
                   result2ItemsRef={result2ItemsRef}
                 />
@@ -513,8 +503,7 @@ export const VisualComparison = ({
                   imageFieldName={imageFieldName}
                   displayField={displayField}
                   getStatusColor={getStatusColor}
-                  handleItemMouseEnter={handleItemMouseEnter}
-                  handleItemMouseLeave={handleItemMouseLeave}
+                  handleItemClick={handleItemClick}
                   result1ItemsRef={result1ItemsRef}
                   result2ItemsRef={result2ItemsRef}
                 />
@@ -550,17 +539,12 @@ export const VisualComparison = ({
             )}
           </div>
 
-          {/* Item Details Tooltip on Hover */}
+          {/* Item Details Tooltip on Click */}
           <ItemDetailHoverPane
-            item={hoveredItem}
+            item={selectedItem}
             mousePosition={mousePosition}
-            onMouseEnter={() => {
-              // Prevent the tooltip from disappearing when mouse enters it
-              if (hoverTimeoutRef.current) {
-                clearTimeout(hoverTimeoutRef.current);
-              }
-            }}
-            onMouseLeave={handleItemMouseLeave}
+            onMouseEnter={() => {}}
+            onMouseLeave={() => setSelectedItem(null)}
             imageFieldName={imageFieldName}
           />
         </EuiPageContent>

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -96,7 +96,22 @@ export const VisualComparison = ({
   resultText1,
   resultText2,
 }: OpenSearchComparisonProps) => {
-  const { lineColors, statusClassName, vennDiagramStyle, hideLegend } = defaultStyle;
+  // Add state for selected style
+  const [selectedStyle, setSelectedStyle] = useState('default');
+  
+  // Get the style based on selection
+  const getCurrentStyle = () => {
+    switch (selectedStyle) {
+      case 'simpler':
+        return simplerVennDiagramStyle;
+      case 'twoColor':
+        return twoColorScheme;
+      default:
+        return defaultStyle;
+    }
+  };
+
+  const { lineColors, statusClassName, vennDiagramStyle, hideLegend } = getCurrentStyle();
 
   // State for selected display field
   const [displayField, setDisplayField] = useState('_id');
@@ -377,6 +392,24 @@ export const VisualComparison = ({
       <EuiPageBody>
         <EuiPageContent>
           <h3 className="text-lg font-semibold mb-2">Results for query: <em>{queryText}</em></h3>
+
+          {/* Style selector dropdown */}
+          <div className="mb-4">
+            <EuiFormRow label="Visualization Style:" id="styleSelectorForm">
+              <EuiSuperSelect
+                id="style-selector"
+                options={[
+                  { value: 'default', inputDisplay: 'Default Style', dropdownDisplay: 'Default Style' },
+                  { value: 'simpler', inputDisplay: 'Simpler Style', dropdownDisplay: 'Simpler Style' },
+                  { value: 'twoColor', inputDisplay: 'Two Color Style', dropdownDisplay: 'Two Color Style' }
+                ]}
+                valueOfSelected={selectedStyle}
+                onChange={(value) => setSelectedStyle(value)}
+                fullWidth
+                hasDividers
+              />
+            </EuiFormRow>
+          </div>
 
           {/* Field selector dropdown */}
           <div className="mb-4">

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -26,44 +26,67 @@ export const convertFromSearchResult = (searchResult) => {
   }));
 }
 
-type LineColors = {
-  unchanged: string;
-  increased: string;
-  decreased: string;
+export const defaultStyle = {
+  lineColors: {
+    unchanged: { stroke: "#93C5FD", strokeWidth: 4 },
+    increased: { stroke: "#86EFAC", strokeWidth: 4 },
+    decreased: { stroke: "#FCA5A5", strokeWidth: 4 },
+  },
+  statusClassName: {
+    unchanged: "bg-blue-300",
+    increased: "bg-green-300",
+    decreased: "bg-red-300",
+    inResult1: "bg-yellow-custom",
+    inResult2: "bg-purple-custom",
+  },
+  vennDiagramStyle: {
+    left: { backgroundColor: "rgba(var(--yellow-custom), 0.9)"},
+    middle: {},
+    right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
+  },
+  hideLegend: [],
 }
 
-type StatusClassName = {
-  unchanged: string;
-  increased: string;
-  decreased: string;
-  inResult1: string;
-  inResult2: string;
+export const simplerVennDiagramStyle = {
+  lineColors: {
+    unchanged: { stroke: "#93C5FD", strokeWidth: 4 },
+    increased: { stroke: "#86EFAC", strokeWidth: 4 },
+    decreased: { stroke: "#FCA5A5", strokeWidth: 4 },
+  },
+  statusClassName: {
+    unchanged: "bg-blue-300",
+    increased: "bg-green-300",
+    decreased: "bg-red-300",
+    inResult1: "bg-purple-custom",
+    inResult2: "bg-purple-custom",
+  },
+  vennDiagramStyle: {
+    left: { backgroundColor: "rgba(var(--purple-custom), 0.9)"},
+    middle: {},
+    right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
+  },
+  hideLegend: ['inResult1', 'inResult2'],
 }
 
-type VennDiagramStyle = {
-  left: { [key: string]: string };
-  middle: { [key: string]: string };
-  right: { [key: string]: string };
-}
-
-const lineColors: LineColors = {
-  unchanged: "#93C5FD",
-  increased: "#86EFAC",
-  decreased: "#FCA5A5",
-}
-
-const statusClassName: StatusClassName = {
-  unchanged: "bg-blue-300",
-  increased: "bg-green-300",
-  decreased: "bg-red-300",
-  inResult1: "bg-yellow-custom",
-  inResult2: "bg-purple-custom",
-}
-
-const vennDiagramStyle: VennDiagramStyle = {
-  left: { backgroundColor: "rgba(var(--yellow-custom), 0.9)"},
-  middle: {},
-  right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
+export const twoColorScheme = {
+  lineColors: {
+    unchanged: { stroke: "black", strokeWidth: 2 },
+    increased: { stroke: "black", strokeWidth: 2 },
+    decreased: { stroke: "black", strokeWidth: 2 },
+  },
+  statusClassName: {
+    unchanged: "bg-blue-100",
+    increased: "bg-blue-100",
+    decreased: "bg-blue-100",
+    inResult1: "bg-purple-custom",
+    inResult2: "bg-purple-custom",
+  },
+  vennDiagramStyle: {
+    left: { backgroundColor: "rgba(var(--purple-custom), 0.9)"},
+    middle: {},
+    right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
+  },
+  hideLegend: ['inResult1', 'inResult2', 'unchanged', 'increased', 'decreased'],
 }
 
 export const VisualComparison = ({
@@ -73,6 +96,8 @@ export const VisualComparison = ({
   resultText1,
   resultText2,
 }: OpenSearchComparisonProps) => {
+  const { lineColors, statusClassName, vennDiagramStyle, hideLegend } = defaultStyle;
+
   // State for selected display field
   const [displayField, setDisplayField] = useState('_id');
   const [imageFieldName, setImageFieldName] = useState(null);
@@ -441,21 +466,31 @@ export const VisualComparison = ({
           </div>
 
           <div className="mt-4 flex gap-4 text-sm">
-            <div className="flex items-center">
-              <div className={`w-4 h-4 ${statusClassName.unchanged} mr-1`}></div> Unchanged position
-            </div>
-            <div className="flex items-center">
-              <div className={`w-4 h-4 ${statusClassName.increased} mr-1`}></div> Increased position
-            </div>
-            <div className="flex items-center">
-              <div className={`w-4 h-4 ${statusClassName.decreased} mr-1`}></div> Decreased position
-            </div>
-            <div className="flex items-center">
-              <div className={`w-4 h-4 ${statusClassName.inResult1} mr-1`}></div> Only in {resultText1}
-            </div>
-            <div className="flex items-center">
-              <div className={`w-4 h-4 ${statusClassName.inResult2} mr-1`}></div> Only in {resultText2}
-            </div>
+            { !hideLegend.includes('unchanged') && (
+              <div className="flex items-center">
+                <div className={`w-4 h-4 ${statusClassName.unchanged} mr-1`}></div> Unchanged rank
+              </div>
+            )}
+            { !hideLegend.includes('increased') && (
+              <div className="flex items-center">
+                <div className={`w-4 h-4 ${statusClassName.increased} mr-1`}></div> Increased rank
+              </div>
+            )}
+            { !hideLegend.includes('decreased') && (
+              <div className="flex items-center">
+                <div className={`w-4 h-4 ${statusClassName.decreased} mr-1`}></div> Decreased rank
+              </div>
+            )}
+            { !hideLegend.includes('inResult1') && (
+              <div className="flex items-center">
+                <div className={`w-4 h-4 ${statusClassName.inResult1} mr-1`}></div> Only in {resultText1}
+              </div>
+            )}
+            { !hideLegend.includes('inResult2') && (
+              <div className="flex items-center">
+                <div className={`w-4 h-4 ${statusClassName.inResult2} mr-1`}></div> Only in {resultText2}
+              </div>
+            )}
           </div>
 
           {/* Item Details Tooltip on Hover */}

--- a/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
+++ b/public/components/query_compare/search_result/visual_comparison/visual_comparison.tsx
@@ -41,7 +41,7 @@ export const defaultStyleConfig = {
   },
   vennDiagramStyle: {
     left: { backgroundColor: "rgba(var(--yellow-custom), 0.9)"},
-    middle: {},
+    middle: { backgroundColor: "rgba(219, 234, 254, 0.7)" },
     right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
   },
   hideLegend: [],
@@ -62,8 +62,29 @@ export const rankingChangeStyleConfig = {
   },
   vennDiagramStyle: {
     left: { backgroundColor: "rgba(var(--purple-custom), 0.9)"},
-    middle: {},
+    middle: { backgroundColor: "rgba(219, 234, 254, 0.7)" },
     right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
+  },
+  hideLegend: ['inResult1', 'inResult2'],
+}
+
+export const rankingChange2StyleConfig = {
+  lineColors: {
+    unchanged: { stroke: "#93C5FD", strokeWidth: 4 },
+    increased: { stroke: "#86EFAC", strokeWidth: 4 },
+    decreased: { stroke: "#FCA5A5", strokeWidth: 4 },
+  },
+  statusClassName: {
+    unchanged: "bg-blue-300",
+    increased: "bg-green-300",
+    decreased: "bg-red-300",
+    inResult1: "rank-no-change",
+    inResult2: "rank-no-change",
+  },
+  vennDiagramStyle: {
+    left: { backgroundColor: "rgba(var(--gray-custom), 0.9)" },
+    middle: { backgroundColor: "rgba(var(--gray-custom), 0.7)" },
+    right: { backgroundColor: "rgba(var(--gray-custom), 0.9)" },
   },
   hideLegend: ['inResult1', 'inResult2'],
 }
@@ -83,7 +104,7 @@ export const vennDiagramStyleConfig = {
   },
   vennDiagramStyle: {
     left: { backgroundColor: "rgba(var(--purple-custom), 0.9)"},
-    middle: {},
+    middle: { backgroundColor: "rgba(219, 234, 254, 0.7)" },
     right: { backgroundColor: "rgba(var(--purple-custom), 0.9)" },
   },
   hideLegend: ['inResult1', 'inResult2', 'unchanged', 'increased', 'decreased'],
@@ -104,6 +125,8 @@ export const VisualComparison = ({
     switch (selectedStyle) {
       case 'simpler':
         return rankingChangeStyleConfig;
+      case 'simpler2':
+        return rankingChange2StyleConfig;
       case 'twoColor':
         return vennDiagramStyleConfig;
       default:
@@ -401,6 +424,7 @@ export const VisualComparison = ({
                 options={[
                   { value: 'default', inputDisplay: 'Default Style', dropdownDisplay: 'Default Style' },
                   { value: 'simpler', inputDisplay: 'Ranking Change Color Coding', dropdownDisplay: 'Ranking Change Color Coding' },
+                  { value: 'simpler2', inputDisplay: 'Ranking Change Color Coding 2', dropdownDisplay: 'Ranking Change Color Coding 2' },
                   { value: 'twoColor', inputDisplay: 'Venn Diagram Color Coding', dropdownDisplay: 'Venn Diagram Color Coding' }
                 ]}
                 valueOfSelected={selectedStyle}


### PR DESCRIPTION
### Description
This PR improves the color coding of results in the eyeballing tool.

The following changes have been made:
 * Improve the standard color coding to match the Venn diagram to the coloring of unique items.
 * Make pop up details pane appear on click rather than on hover.
 * Keep style selection widget under the legend hidden under an accordion.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
