### PR TITLE
Expose hybrid optimizer in the left nav and expose place holder page

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -31,6 +31,7 @@ enum Navigation {
   ExperimentsSingleQueryComparison = 'Single Query Comparison',
   ExperimentsQuerySetComparison = 'Query Set Comparison',
   ExperimentsSearchEvaluation = 'Search Evaluation',
+  ExperimentsHybridOptimizer = 'Hybrid Optimizer',
   QuerySets = 'Query Sets',
   SearchConfigurations = 'Search Configurations',
   Judgments = 'Judgments',
@@ -67,6 +68,9 @@ const SearchRelevancePage = ({history}) => {
     if (selectedNavItem === Navigation.ExperimentsSearchEvaluation) {
       return TemplateType.SearchEvaluation;
     }
+    if (selectedNavItem === Navigation.ExperimentsHybridOptimizer) {
+      return TemplateType.HybridSearchOptimizer;
+    }
     return null;
   }
 
@@ -79,6 +83,9 @@ const SearchRelevancePage = ({history}) => {
     }
     if (templateId === TemplateType.SearchEvaluation) {
       setSelectedNavItem(Navigation.ExperimentsSearchEvaluation);
+    }
+    if (templateId === TemplateType.HybridSearchOptimizer) {
+      setSelectedNavItem(Navigation.ExperimentsHybridOptimizer);
     }
   }
 
@@ -142,6 +149,15 @@ const SearchRelevancePage = ({history}) => {
                 setSelectedNavItem(Navigation.ExperimentsSearchEvaluation);
               },
               isSelected: selectedNavItem === Navigation.ExperimentsSearchEvaluation,
+            },
+            {
+              name: Navigation.ExperimentsHybridOptimizer,
+              id: Navigation.ExperimentsHybridOptimizer,
+              onClick: () => {
+                history.push("/experiment/create");
+                setSelectedNavItem(Navigation.ExperimentsHybridOptimizer);
+              },
+              isSelected: selectedNavItem === Navigation.ExperimentsHybridOptimizer,
             },
           ]
         },

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -82,17 +82,7 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
         );
       case TemplateType.HybridSearchOptimizer:
         return (
-          <>
-            <LLMForm formData={formData as LLMFormData} onChange={handleChange} />
-
-            <EuiFlexGroup justifyContent="flexEnd">
-              <EuiFlexItem grow={false}>
-                <EuiFormRow hasEmptyLabelSpace>
-                  <EuiButton onClick={handleSave}>Save Judgement</EuiButton>
-                </EuiFormRow>
-              </EuiFlexItem>
-            </EuiFlexGroup>
-          </>
+          <UserBehaviorForm formData={formData as UserBehaviorFormData} onChange={handleChange} http={http} />
         );
       default:
         return null;


### PR DESCRIPTION
### Description
This adds back the Hybrid Optimizer in the left Nav and a placeholder page.

@martin-gaievski and I did some pairing and discovered that ALL the params for Hybrid Optimizer are the same as those for a Pointwise Evaluation.   

We quickly made that work.

![image](https://github.com/user-attachments/assets/6019afab-b212-4a5c-aab2-750ec6f29f7a)


However, I would like to refactor the names of the template files in the front end UI code:

![image](https://github.com/user-attachments/assets/5b9a1f14-5cf6-48c8-b809-2d2744612264)

We should have `PointwiseExperimentForm` and `HybridOptimizerExperimentForm` instead of `UserBehaviorForm`.   

@martin-gaievski recommended that be a seperate PR, so I'll do it tomorrow once this is in!

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
