### PR TITLE
Add advanced setup for llm as a judgment

### DIFF
--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -30,7 +30,7 @@ const getInitialFormData = (templateType: TemplateType): ConfigurationFormData =
       return {
         ...baseData,
         judgmentList: [],
-        type: "UBI_EVALUATION",
+        type: "POINTWISE_EVALUATION",
       };
     default:
       return (baseData as unknown) as

--- a/public/components/experiment_view/evaluation_experiment_view.tsx
+++ b/public/components/experiment_view/evaluation_experiment_view.tsx
@@ -16,7 +16,7 @@ import {
 import {
     TableListView,
     reactRouterNavigate,
-} from '../../../../../src/plugins/opensearch_dashboards_react/public';  
+} from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
 import { CoreStart } from '../../../../../src/core/public';
@@ -65,7 +65,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
 
         const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]);
         const query = {
-            index: ".plugins-search-relevance-evaluation-result",
+            index: "search-relevance-evaluation-result",
             query: {
               terms: {
                 _id: resultIds
@@ -75,7 +75,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
         const result = await http.post(ServiceEndpoints.GetSearchResults, {
             body: JSON.stringify({ query1: query }),
         })
-        const parseResults = result && result.result1?.hits?.hits && combineResults(...result.result1.hits.hits.map((x) => toQueryEvaluation(x._source)))    
+        const parseResults = result && result.result1?.hits?.hits && combineResults(...result.result1.hits.hits.map((x) => toQueryEvaluation(x._source)))
 
         if (_experiment && _searchConfiguration && _querySet && _judgmentSet) {
           setExperiment(_experiment);

--- a/public/components/experiment_view/experiment_view.tsx
+++ b/public/components/experiment_view/experiment_view.tsx
@@ -56,14 +56,14 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
       <EuiPageHeader
         pageTitle="Experiment Visualization"
       />
-      {experiment && experiment.type === "PAIRWISE_COMPARISON" &&
+      {experiment && experiment.type === 'PAIRWISE_COMPARISON' &&
         <PairwiseExperimentViewWithRouter
           http={http}
           inputExperiment={experiment}
           history={history}
         />
       }
-      {experiment && experiment.type === "UBI_EVALUATION" &&
+      {experiment && experiment.type === 'POINTWISE_EVALUATION' &&
         <EvaluationExperimentViewWithRouter
           http={http}
           inputExperiment={experiment}

--- a/public/components/judgment_create/judgment_create.tsx
+++ b/public/components/judgment_create/judgment_create.tsx
@@ -16,6 +16,11 @@ import {
   EuiPageHeader,
   EuiFieldText,
   EuiComboBox,
+  EuiSpacer,
+  EuiBadge,
+  EuiSwitch,
+  EuiFlexGroup,
+  EuiAccordion,
 } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { withRouter } from 'react-router-dom';
@@ -38,8 +43,12 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
   const [type, setType] = useState<JudgmentType>(JudgmentType.LLM);
 
   // LLM specific states
-  const [querySetOptions, setQuerySetOptions] = useState<Array<{ label: string; value: string }>>([]);
-  const [selectedQuerySet, setSelectedQuerySet] = useState<Array<{ label: string; value: string }>>([]);
+  const [querySetOptions, setQuerySetOptions] = useState<Array<{ label: string; value: string }>>(
+    []
+  );
+  const [selectedQuerySet, setSelectedQuerySet] = useState<Array<{ label: string; value: string }>>(
+    []
+  );
   const [searchConfigOptions, setSearchConfigOptions] = useState<
     Array<{ label: string; value: string }>
   >([]);
@@ -48,6 +57,12 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
   >([]);
   const [size, setSize] = useState(5);
   const [modelId, setModelId] = useState('');
+  // Optional LLM states
+  const [isAdvancedSettingsOpen, setIsAdvancedSettingsOpen] = useState(false);
+  const [contextFields, setContextFields] = useState<string[]>([]);
+  const [newContextField, setNewContextField] = useState('');
+  const [tokenLimit, setTokenLimit] = useState<number>(4000);
+  const [ignoreFailure, setIgnoreFailure] = useState<boolean>(false);
 
   // UBI specific states
   const [clickModel, setClickModel] = useState('coec');
@@ -128,6 +143,20 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
     return isValid;
   };
 
+  const addContextField = useCallback(() => {
+    if (newContextField && !contextFields.includes(newContextField)) {
+      setContextFields([...contextFields, newContextField]);
+      setNewContextField('');
+    }
+  }, [newContextField, contextFields]);
+
+  const removeContextField = useCallback(
+    (field: string) => {
+      setContextFields(contextFields.filter((f) => f !== field));
+    },
+    [contextFields]
+  );
+
   // Handle form submission
   const createJudgment = useCallback(() => {
     if (!validateForm()) {
@@ -143,6 +172,9 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
             searchConfigurationList: selectedSearchConfigs.map((config) => config.value),
             size,
             modelId,
+            ...(contextFields.length > 0 && { contextFields }),
+            ...(tokenLimit !== 4000 && { tokenLimit: tokenLimit.toString() }),
+            ...(ignoreFailure && { ignoreFailure }),
           }
         : {
             name,
@@ -173,6 +205,9 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
     http,
     notifications.toasts,
     history,
+    contextFields,
+    tokenLimit,
+    ignoreFailure,
   ]);
 
   const handleCancel = () => {
@@ -230,14 +265,15 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
               />
             </EuiCompressedFormRow>
 
-            <EuiCompressedFormRow 
-              label="Type" 
+            <EuiCompressedFormRow
+              label="Type"
               helpText={
                 <p>
                   There are many types of judgments available. Learn more in{' '}
                   <a href="https://opensearch.org/docs/latest/search-plugins/search-relevance/index/">
                     Types of Judgments
-                  </a>.
+                  </a>
+                  .
                 </p>
               }
               fullWidth
@@ -277,7 +313,7 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
                   />
                 </EuiCompressedFormRow>
 
-                <EuiCompressedFormRow 
+                <EuiCompressedFormRow
                   label="K Value"
                   helpText="The number of documents from the result list to include in the judging process."
                   fullWidth
@@ -301,6 +337,99 @@ export const JudgmentCreate: React.FC<JudgmentCreateProps> = ({ http, notificati
                     fullWidth
                   />
                 </EuiCompressedFormRow>
+
+                <EuiSpacer size="m" />
+                <EuiAccordion
+                  id="advancedSettings"
+                  buttonContent="Advanced Settings"
+                  paddingSize="m"
+                  isOpen={isAdvancedSettingsOpen}
+                  onToggle={(isOpen) => setIsAdvancedSettingsOpen(isOpen)}
+                >
+                  <EuiSpacer size="m" />
+
+                  <EuiCompressedFormRow
+                    label="Context Fields"
+                    helpText="Specify context fields used for the LLM judgment."
+                    fullWidth
+                  >
+                    <div>
+                      <EuiFlexGroup gutterSize="s">
+                        <EuiFlexItem>
+                          <EuiFieldText
+                            placeholder="Enter field name"
+                            value={newContextField}
+                            onChange={(e) => setNewContextField(e.target.value)}
+                            onKeyUp={(e) => {
+                              if (e.key === 'Enter' && newContextField.trim()) {
+                                addContextField();
+                              }
+                            }}
+                            fullWidth
+                          />
+                        </EuiFlexItem>
+                        <EuiFlexItem grow={false}>
+                          <EuiButton
+                            size="m"
+                            onClick={addContextField}
+                            isDisabled={!newContextField.trim()}
+                          >
+                            Add
+                          </EuiButton>
+                        </EuiFlexItem>
+                      </EuiFlexGroup>
+
+                      {contextFields.length > 0 && (
+                        <>
+                          <EuiSpacer size="s" />
+                          <div>
+                            {contextFields.map((field) => (
+                              <EuiBadge
+                                key={field}
+                                color="hollow"
+                                onClose={() => removeContextField(field)}
+                                style={{ marginRight: '4px', marginBottom: '4px' }}
+                              >
+                                {field}
+                              </EuiBadge>
+                            ))}
+                          </div>
+                        </>
+                      )}
+                    </div>
+                  </EuiCompressedFormRow>
+
+                  <EuiCompressedFormRow
+                    label="Token Limit"
+                    helpText="Please check token limit for the modelId (1000-500000)"
+                    fullWidth
+                  >
+                    <EuiFieldNumber
+                      value={tokenLimit}
+                      onChange={(e) => {
+                        const value = parseInt(e.target.value, 10);
+                        if (value >= 1000 && value <= 500000) {
+                          setTokenLimit(value);
+                        }
+                      }}
+                      min={1000}
+                      max={500000}
+                      fullWidth
+                    />
+                  </EuiCompressedFormRow>
+
+                  <EuiCompressedFormRow
+                    label="Ignore Failure"
+                    helpText="Continue processing even if some judgments fail"
+                    fullWidth
+                  >
+                    <EuiSwitch
+                      label="Ignore failures during judgment process"
+                      checked={ignoreFailure}
+                      onChange={(e) => setIgnoreFailure(e.target.checked)}
+                    />
+                  </EuiCompressedFormRow>
+                </EuiAccordion>
               </>
             ) : (
               <>

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -102,7 +102,7 @@ export type PairwiseComparisonExperiment =
 
 export type EvaluationExperiment =
   (ExperimentBase & {
-    type: "UBI_EVALUATION";
+    type: "POINTWISE_EVALUATION";
     searchConfigurationId: string;
     judgmentId: string;
   })
@@ -111,7 +111,7 @@ export const printType = (type: string) => {
   switch (type) {
     case "PAIRWISE_COMPARISON":
       return "Comparison";
-    case "UBI_EVALUATION":
+    case "POINTWISE_EVALUATION":
       return "Evaluation";
     default:
       return "Unknown";
@@ -135,7 +135,7 @@ export type QuerySnapshot = {
   documentIds: string[];
 }
 
-export type ParseResult<T> = 
+export type ParseResult<T> =
   | { success: true; data: T }
   | { success: false; errors: string[] };
 
@@ -265,7 +265,7 @@ export const toExperiment = (source: any): ParseResult<Experiment> => {
       },
     };
 
-  case "UBI_EVALUATION":
+  case "POINTWISE_EVALUATION":
     if (source.searchConfigurationList.length < 1) {
       return parseError("Missing search configuration for UBI evaluation (searchConfigurationList).");
     }
@@ -275,7 +275,7 @@ export const toExperiment = (source: any): ParseResult<Experiment> => {
     return {
       success: true,
       data: {
-        type: "UBI_EVALUATION",
+        type: "POINTWISE_EVALUATION",
         status: source.status,
         id: source.id,
         k: source.size,


### PR DESCRIPTION
### Description
There are couple advanced setup for llm judgment creation. 
- context fields - define against which fields, customers want to execute the search relevance at. 
- tokenLimit - by defaulted to be 4000. But based on the model type, token limit can be really different. Say, if token limit for a model is 1000, then if customer selected to use defaulted value, it will cause an error. If token limit for a model is 500000, then if customer selected to use defaulted value, it won't cause an error, but it will still process chunks in 4000, which is wasting the resources. 
- ignoreFailure - by defaulted to be false. If false, the chunk processing will terminate immediately when it meets any issue. If true, the chunk processing will continue execution and keep succeeded results.

<img width="1463" alt="Screenshot 2025-05-28 at 4 39 10 PM" src="https://github.com/user-attachments/assets/4a413cac-4ff3-45fb-b19d-9fc065ce55fd" />

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
