### PR TITLE
remove template from search config input form

### DIFF
--- a/public/components/search_config_create/search_configuration_form.tsx
+++ b/public/components/search_config_create/search_configuration_form.tsx
@@ -145,7 +145,7 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
           Search Pipeline <i> - optional </i>
         </p>
       }
-      helpText="Define the search pipeline to be used." 
+      helpText="Define the search pipeline to be used."
       fullWidth
     >
       <EuiComboBox
@@ -163,22 +163,5 @@ export const SearchConfigurationForm: React.FC<SearchConfigurationFormProps> = (
       />
     </EuiFormRow>
 
-    <EuiFormRow
-      label={
-        <p>
-          Search Template <i> - optional </i>
-        </p>
-      }
-      helpText="Define the search template."
-      fullWidth
-    >
-      <EuiFieldText
-        placeholder="Enter search template"
-        value={searchTemplate}
-        onChange={(e) => setSearchTemplate(e.target.value)}
-        fullWidth
-        disabled={disabled}
-      />
-    </EuiFormRow>
   </EuiForm>
 );


### PR DESCRIPTION
### Description
Specifying a template when creating a search configuration currently is without effect: it is not sent as a parameter to the API endpoint, the endpoint wouldn't accept it, using it in an experiment wouldn't work.

Given the time constraints for the 3.1 release I propose to remove the input field from the search configuration input form to not indicate a feature that isn't there.

See https://github.com/opensearch-project/search-relevance/issues/36 for more context from the backend point of view.

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
