### PR TITLE
Add access control via SRW feature flag in cluster settings

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -14,6 +14,7 @@ export enum ServiceEndpoints {
   GetSearchResults = '/api/relevancy/search',
   GetSingleSearchResults = '/api/relevancy/single_search',
   GetStats = '/api/relevancy/stats',
+  GetClusterSettings = '/api/relevancy/cluster_settings',
 
   // Search Relevance node APIs
   QuerySets = '/api/relevancy/query_sets',

--- a/public/application.tsx
+++ b/public/application.tsx
@@ -19,6 +19,17 @@ export const renderApp = (
   dataSourceManagement: DataSourceManagementPluginSetup
 ) => {
   const { notifications, http, chrome, savedObjects, application, uiSettings } = coreStart;
+  const props = {
+    notifications,
+    http,
+    navigation,
+    chrome,
+    savedObjects,
+    dataSourceEnabled: !!dataSource,
+    dataSourceManagement,
+    setActionMenu: setHeaderActionMenu,
+    application,
+  };
 
   ReactDOM.render(
     <OpenSearchDashboardsContextProvider services={coreStart}>
@@ -29,7 +40,7 @@ export const renderApp = (
         setHeaderActionMenu={setHeaderActionMenu}
         navigation={navigation}
       >
-        <SearchRelevanceApp/>
+        <SearchRelevanceApp {...props} />
       </ConfigProvider>
     </OpenSearchDashboardsContextProvider>,
     element

--- a/server/metrics/index.ts
+++ b/server/metrics/index.ts
@@ -21,4 +21,5 @@ export enum METRIC_ACTION {
   SINGLE_SEARCH = 'single_search',
   FETCH_INDEX = 'fetch_index',
   FETCH_PIPELINE = 'fetch_pipeline',
+  FETCH_CLUSTER_SETTINGS = 'fetch_cluster_settings',
 }


### PR DESCRIPTION
### Description
- feature flag is added for SRW in cluster settings
- feature flag by defaulted is true
<img width="1778" alt="Screenshot 2025-05-30 at 2 36 59 PM" src="https://github.com/user-attachments/assets/a9eec192-6d67-4d84-9758-3663039df7da" />

- when customers opt-out new experience and want to use old experience
<img width="1774" alt="Screenshot 2025-05-30 at 2 36 32 PM" src="https://github.com/user-attachments/assets/be0d1f24-4849-49ae-89f4-5baca52d60a6" />

### Tests
- check original feature flag -> it should return true in defaults 
```json
GET localhost:9200/_cluster/settings?include_defaults=true
```
- change feature flag due to Dynamic setup, it should update flag in persistence
```json
PUT localhost:9200/_cluster/settings
{
  "persistent": {
   "plugins.search_relevance.workbench_enabled": false
  }
}

```


### Issues Resolved
- https://github.com/opensearch-project/search-relevance/issues/33

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
