### PR TITLE
Filter out queries that have no documents (zsr) and use the correct system index

### DIFF
--- a/public/components/experiment_view/evaluation_experiment_view.tsx
+++ b/public/components/experiment_view/evaluation_experiment_view.tsx
@@ -65,7 +65,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
 
         const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]).filter(id => id !== undefined);
         const query = {
-            index: ".plugins-search-relevance-evaluation-result",
+            index: "search-relevance-evaluation-result",
             query: {
               terms: {
                 _id: resultIds

--- a/public/components/experiment_view/evaluation_experiment_view.tsx
+++ b/public/components/experiment_view/evaluation_experiment_view.tsx
@@ -63,9 +63,9 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
         const _querySet = _experiment && await http.get(ServiceEndpoints.QuerySets + "/" + inputExperiment.querySetId).then(sanitizeResponse);
         const _judgmentSet = _experiment && await http.get(ServiceEndpoints.Judgments + "/" + inputExperiment.judgmentId).then(sanitizeResponse);
 
-        const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]);
+        const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]).filter(id => id !== undefined);
         const query = {
-            index: "search-relevance-evaluation-result",
+            index: ".plugins-search-relevance-evaluation-result",
             query: {
               terms: {
                 _id: resultIds


### PR DESCRIPTION

### Description
Queries that return ZSR caused the detail query to fail.

Update to the current system index.

### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
