### PR TITLE
Rework navigation

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -35,3 +35,35 @@ export const SEARCH_API = '/_search';
 // Query1 for the left search and Query2 for the right search page
 export const QUERY_NUMBER_ONE = '1';
 export const QUERY_NUMBER_TWO = '2';
+
+export enum RouteTemplateType {
+  SingleQueryComparison = 'singleQueryComparison',
+  QuerySetComparison = 'querySetComparison',
+  SearchEvaluation = 'searchEvaluation',
+  HybridOptimizer = 'hybridOptimizer',
+}
+
+export enum Routes {
+  Home = '/',
+  ExperimentListing = '/experiment',
+  ExperimentView = '/experiment/view/:entityId',
+  ExperimentViewPrefix = '/experiment/view',
+  ExperimentCreate = '/experiment/create',
+  ExperimentCreateSingleQueryComparison = `/experiment/create/${RouteTemplateType.SingleQueryComparison}`,
+  ExperimentCreateQuerySetComparison = `/experiment/create/${RouteTemplateType.QuerySetComparison}`,
+  ExperimentCreateSearchEvaluation = `/experiment/create/${RouteTemplateType.SearchEvaluation}`,
+  ExperimentCreateHybridOptimizer = `/experiment/create/${RouteTemplateType.HybridOptimizer}`,
+  ExperimentCreateTemplate = `/experiment/create/:templateId(${Object.values(RouteTemplateType).join('|')})`,
+  QuerySetListing = '/querySet',
+  QuerySetView = '/querySet/view/:entityId',
+  QuerySetViewPrefix = '/querySet/view',
+  QuerySetCreate = '/querySet/create',
+  SearchConfigurationListing = '/searchConfiguration',
+  SearchConfigurationView = '/searchConfiguration/view/:entityId',
+  SearchConfigurationViewPrefix = '/searchConfiguration/view',
+  SearchConfigurationCreate = '/searchConfiguration/create',
+  JudgmentListing = '/judgment',
+  JudgmentView = '/judgment/view/:entityId',
+  JudgmentViewPrefix = '/judgment/view',
+  JudgmentCreate = '/judgment/create',
+}

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -10,14 +10,13 @@ import { HashRouter, Route, Switch, withRouter, useLocation } from 'react-router
 import { CoreStart, MountPoint, Toast, ReactChild } from '../../../../src/core/public';
 import { DataSourceManagementPluginSetup } from '../../../../src/plugins/data_source_management/public';
 import { NavigationPublicPluginStart } from '../../../../src/plugins/navigation/public';
-import { PLUGIN_NAME, COMPARE_SEARCH_RESULTS_TITLE, ServiceEndpoints } from "../../common";
+import { PLUGIN_NAME, COMPARE_SEARCH_RESULTS_TITLE, ServiceEndpoints, Routes } from "../../common";
 import { SearchRelevanceContextProvider } from '../contexts';
 import { Home as QueryCompareHome } from './query_compare/home';
 import { useOpenSearchDashboards } from '../../../../src/plugins/opensearch_dashboards_react/public';
 import { EuiPageSideBar, EuiSideNav, EuiTitle, EuiSpacer, EuiPage, EuiPageBody, EuiLoadingSpinner } from '@elastic/eui';
 import { ExperimentListingWithRoute } from './experiment_listing';
 import { ExperimentViewWithRouter } from './experiment_view/experiment_view';
-import { TemplateCards } from './experiment_create/template_card/template_cards';
 import { QuerySetListingWithRoute } from './query_set_listing';
 import { SearchConfigurationListingWithRoute } from './search_config_listing';
 import { JudgmentListingWithRoute } from './judgment_listing';
@@ -28,7 +27,8 @@ import { QuerySetCreateWithRouter } from './query_set_create/query_set_create';
 import { SearchConfigurationCreateWithRouter } from './search_config_create/search_config_create';
 import { JudgmentCreateWithRouter } from './judgment_create/judgment_create';
 import { GetStartedAccordion } from './resource_management_home/get_started_accordion';
-import { TemplateType } from './experiment_create/configuration/types';
+import { TemplateType, routeToTemplateType } from './experiment_create/configuration/types';
+import { TemplateConfigurationWithRouter } from './experiment_create/configuration/template_configuration';
 
 enum Navigation {
   SRW = 'Search Relevance Workbench',
@@ -56,56 +56,29 @@ interface SearchRelevanceAppDeps {
   isNewExperienceEnabled?: boolean;
 }
 
-const SearchRelevancePage = ({history}) => {
+interface SearchRelevancePageProps extends SearchRelevanceAppDeps {
+  history: any; // From withRouter
+}
+
+const SearchRelevancePage = ({
+  history,
+  application,
+  notifications,
+  http,
+  navigation,
+  chrome,
+  savedObjects,
+  dataSourceEnabled,
+  dataSourceManagement,
+  setActionMenu,
+}: SearchRelevancePageProps) => {
   const location = useLocation();
-  const { http, notifications } = useOpenSearchDashboards().services;
+  const { http: osDashboardsHttp } = useOpenSearchDashboards().services;
 
-  const routeToSelectedNavItem = (pathname: string) => {
-    if (pathname === '/') {
-      return Navigation.Overview;
-    } else if (pathname.startsWith('/experiment')) {
-      return Navigation.Experiments;
-    } else if (pathname.startsWith('/querySet')) {
-      return Navigation.QuerySets;
-    } else if (pathname.startsWith('/searchConfiguration')) {
-      return Navigation.SearchConfigurations;
-    } else if (pathname.startsWith('/judgment')) {
-      return Navigation.Judgments;
-    }
-  }
-
-  const [selectedNavItem, setSelectedNavItem] = useState<Navigation | null>(routeToSelectedNavItem(location.pathname));
-
-  const extractSelectedTemplate = (selectedNavItem: Navigation) => {
-    if (selectedNavItem === Navigation.ExperimentsSingleQueryComparison) {
-      return TemplateType.SingleQueryComparison;
-    }
-    if (selectedNavItem === Navigation.ExperimentsQuerySetComparison) {
-      return TemplateType.QuerySetComparison;
-    }
-    if (selectedNavItem === Navigation.ExperimentsSearchEvaluation) {
-      return TemplateType.SearchEvaluation;
-    }
-    if (selectedNavItem === Navigation.ExperimentsHybridOptimizer) {
-      return TemplateType.HybridSearchOptimizer;
-    }
-    return null;
-  }
-
-  const onCardClick = (templateId: TemplateType) => {
-    if (templateId === TemplateType.SingleQueryComparison) {
-      setSelectedNavItem(Navigation.ExperimentsSingleQueryComparison);
-    }
-    if (templateId === TemplateType.QuerySetComparison) {
-      setSelectedNavItem(Navigation.ExperimentsQuerySetComparison);
-    }
-    if (templateId === TemplateType.SearchEvaluation) {
-      setSelectedNavItem(Navigation.ExperimentsSearchEvaluation);
-    }
-    if (templateId === TemplateType.HybridSearchOptimizer) {
-      setSelectedNavItem(Navigation.ExperimentsHybridOptimizer);
-    }
-  }
+  const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
+  const parentBreadCrumbs = getNavGroupEnabled
+    ? [{ text: COMPARE_SEARCH_RESULTS_TITLE, href: '#' }]
+    : [{ text: PLUGIN_NAME, href: '#' }];
 
   const sideNavItems = [
     {
@@ -126,56 +99,50 @@ const SearchRelevancePage = ({history}) => {
           name: Navigation.Overview,
           id: Navigation.Overview,
           onClick: () => {
-            history.push('/');
-            setSelectedNavItem(Navigation.Overview);
+            history.push(Routes.Home);
           },
-          isSelected: selectedNavItem === Navigation.Overview
+          isSelected: location.pathname === Routes.Home
         },
         {
           name: Navigation.Experiments,
           id: Navigation.Experiments,
           onClick: () => {
-            history.push("/experiment");
-            setSelectedNavItem(Navigation.Experiments);
+            history.push(Routes.ExperimentListing);
           },
-          isSelected: selectedNavItem === Navigation.Experiments,
+          isSelected: location.pathname === Routes.ExperimentListing || location.pathname.startsWith(Routes.ExperimentViewPrefix),
           forceOpen: true,
           items: [
             {
               name: Navigation.ExperimentsSingleQueryComparison,
               id: Navigation.ExperimentsSingleQueryComparison,
               onClick: () => {
-                history.push("/experiment/create");
-                setSelectedNavItem(Navigation.ExperimentsSingleQueryComparison);
+                history.push(Routes.ExperimentCreateSingleQueryComparison);
               },
-              isSelected: selectedNavItem === Navigation.ExperimentsSingleQueryComparison,
+              isSelected: location.pathname.startsWith(Routes.ExperimentCreateSingleQueryComparison),
             },
             {
               name: Navigation.ExperimentsQuerySetComparison,
               id: Navigation.ExperimentsQuerySetComparison,
               onClick: () => {
-                history.push("/experiment/create");
-                setSelectedNavItem(Navigation.ExperimentsQuerySetComparison);
+                history.push(Routes.ExperimentCreateQuerySetComparison);
               },
-              isSelected: selectedNavItem === Navigation.ExperimentsQuerySetComparison,
+              isSelected: location.pathname.startsWith(Routes.ExperimentCreateQuerySetComparison),
             },
             {
               name: Navigation.ExperimentsSearchEvaluation,
               id: Navigation.ExperimentsSearchEvaluation,
               onClick: () => {
-                history.push("/experiment/create");
-                setSelectedNavItem(Navigation.ExperimentsSearchEvaluation);
+                history.push(Routes.ExperimentCreateSearchEvaluation);
               },
-              isSelected: selectedNavItem === Navigation.ExperimentsSearchEvaluation,
+              isSelected: location.pathname.startsWith(Routes.ExperimentCreateSearchEvaluation),
             },
             {
               name: Navigation.ExperimentsHybridOptimizer,
               id: Navigation.ExperimentsHybridOptimizer,
               onClick: () => {
-                history.push("/experiment/create");
-                setSelectedNavItem(Navigation.ExperimentsHybridOptimizer);
+                history.push(Routes.ExperimentCreateHybridOptimizer);
               },
-              isSelected: selectedNavItem === Navigation.ExperimentsHybridOptimizer,
+              isSelected: location.pathname.startsWith(Routes.ExperimentCreateHybridOptimizer),
             },
           ]
         },
@@ -183,28 +150,25 @@ const SearchRelevancePage = ({history}) => {
           name: Navigation.QuerySets,
           id: Navigation.QuerySets,
           onClick: () => {
-            history.push("/querySet");
-            setSelectedNavItem(Navigation.QuerySets);
+            history.push(Routes.QuerySetListing);
           },
-          isSelected: selectedNavItem === Navigation.QuerySets,
+          isSelected: location.pathname.startsWith(Routes.QuerySetListing),
         },
         {
           name: Navigation.SearchConfigurations,
           id: Navigation.SearchConfigurations,
           onClick: () => {
-            history.push("/searchConfiguration");
-            setSelectedNavItem(Navigation.SearchConfigurations);
+            history.push(Routes.SearchConfigurationListing);
           },
-          isSelected: selectedNavItem === Navigation.SearchConfigurations,
+          isSelected: location.pathname.startsWith(Routes.SearchConfigurationListing),
         },
         {
           name: Navigation.Judgments,
           id: Navigation.Judgments,
           onClick: () => {
-            history.push("/judgment");
-            setSelectedNavItem(Navigation.Judgments);
+            history.push(Routes.JudgmentListing);
           },
-          isSelected: selectedNavItem === Navigation.Judgments,
+          isSelected: location.pathname.startsWith(Routes.JudgmentListing),
         },
       ],
     },
@@ -220,49 +184,79 @@ const SearchRelevancePage = ({history}) => {
           <Route path="/" exact render={() => {
             return <GetStartedAccordion isOpen={true} />;
           }} />
-          <Route path="/experiment" exact render={() => {
+          <Route path={Routes.ExperimentListing} exact render={() => {
             return <ExperimentListingWithRoute http={http} />;
           }} />
-          <Route path="/querySet" exact render={() => {
+          <Route path={Routes.QuerySetListing} exact render={() => {
             return <QuerySetListingWithRoute http={http} />;
           }} />
-          <Route path="/searchConfiguration" exact render={() => {
+          <Route path={Routes.SearchConfigurationListing} exact render={() => {
             return <SearchConfigurationListingWithRoute http={http} />;
           }} />
-          <Route path="/judgment" exact render={() => {
+          <Route path={Routes.JudgmentListing} exact render={() => {
             return <JudgmentListingWithRoute http={http} />;
           }} />
-          <Route path="/experiment/view/:entityId" exact render={(props) => {
+          <Route path={Routes.ExperimentView} exact render={(props) => {
             const { entityId } = props.match.params;
             return <ExperimentViewWithRouter http={http} id={entityId} />;
           }} />
-          <Route path="/querySet/view/:entityId" exact render={(props) => {
+          <Route path={Routes.QuerySetView} exact render={(props) => {
             const { entityId } = props.match.params;
             return <QuerySetView http={http} id={entityId} />;
           }} />
-          <Route path="/searchConfiguration/view/:entityId" exact render={(props) => {
+          <Route path={Routes.SearchConfigurationView} exact render={(props) => {
             const { entityId } = props.match.params;
             return <SearchConfigurationView http={http} id={entityId} />;
           }} />
-          <Route path="/judgment/view/:entityId" exact render={(props) => {
+          <Route path={Routes.JudgmentView} exact render={(props) => {
             const { entityId } = props.match.params;
             return <JudgmentView http={http} id={entityId} />;
           }} />
-          <Route path="/experiment/create" exact render={() => {
-            return <TemplateCards
-              key={`selection-${selectedNavItem}`}
-              onClose={() => {}}
-              inputSelectedTemplate={extractSelectedTemplate(selectedNavItem)}
-              onCardClick={onCardClick}
-            />;
-          }} />
-          <Route path="/querySet/create" exact render={() => {
+          <Route
+            path={Routes.ExperimentCreateTemplate}
+            exact
+            render={(props) => {
+              const templateId = routeToTemplateType(props.match.params.templateId)
+              if (templateId === TemplateType.SingleQueryComparison) {
+                return <QueryCompareHome
+                  application={application}
+                  parentBreadCrumbs={parentBreadCrumbs}
+                  notifications={notifications}
+                  http={http}
+                  navigation={navigation}
+                  setBreadcrumbs={chrome.setBreadcrumbs}
+                  chrome={chrome}
+                  savedObjects={savedObjects}
+                  dataSourceEnabled={dataSourceEnabled}
+                  dataSourceManagement={dataSourceManagement}
+                  setActionMenu={setActionMenu}
+                  setToast={(title: string, color = 'success', text?: React.ReactNode) => {
+                    if (color === 'success') {
+                      notifications.toasts.addSuccess({ title, text });
+                    } else if (color === 'warning') {
+                      notifications.toasts.addWarning({ title, text });
+                    } else if (color === 'danger') {
+                      notifications.toasts.addDanger({ title, text });
+                    } else {
+                      notifications.toasts.add({ title, text });
+                    }
+                  }}
+                />                        
+              } else {
+                return <TemplateConfigurationWithRouter
+                  templateType={templateId}
+                  onBack={() => { history.goBack(); }}
+                  onClose={() => {}}
+                />;
+              }
+            }} />
+          <Route path={Routes.QuerySetCreate} exact render={() => {
             return <QuerySetCreateWithRouter http={http} notifications={notifications} />;
           }} />
-          <Route path="/searchConfiguration/create" exact render={() => {
+          <Route path={Routes.SearchConfigurationCreate} exact render={() => {
             return <SearchConfigurationCreateWithRouter http={http} notifications={notifications} />;
           }} />
-          <Route path="/judgment/create" exact render={() => {
+          <Route path={Routes.JudgmentCreate} exact render={() => {
             return <JudgmentCreateWithRouter http={http} notifications={notifications} history={history}/>;
           }} />
         </Switch>
@@ -348,7 +342,18 @@ export const SearchRelevanceApp = ({
     <HashRouter>
       <I18nProvider>
         <SearchRelevanceContextProvider>
-          <SearchRelevancePageWithRouter />
+          <SearchRelevancePageWithRouter
+            application={application}
+            parentBreadCrumbs={parentBreadCrumbs}
+            notifications={notifications}
+            http={http}
+            navigation={navigation}
+            chrome={chrome}
+            savedObjects={savedObjects}
+            dataSourceEnabled={dataSourceEnabled}
+            dataSourceManagement={dataSourceManagement}
+            setActionMenu={setActionMenu}
+          />
         </SearchRelevanceContextProvider>
       </I18nProvider>
     </HashRouter>

--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -96,20 +96,12 @@ const SearchRelevancePage = ({
       },
       items: [
         {
-          name: Navigation.Overview,
-          id: Navigation.Overview,
-          onClick: () => {
-            history.push(Routes.Home);
-          },
-          isSelected: location.pathname === Routes.Home
-        },
-        {
           name: Navigation.Experiments,
           id: Navigation.Experiments,
           onClick: () => {
-            history.push(Routes.ExperimentListing);
+            history.push(Routes.Home);
           },
-          isSelected: location.pathname === Routes.ExperimentListing || location.pathname.startsWith(Routes.ExperimentViewPrefix),
+          isSelected: location.pathname === Routes.Home || location.pathname.startsWith(Routes.ExperimentViewPrefix),
           forceOpen: true,
           items: [
             {
@@ -181,10 +173,7 @@ const SearchRelevancePage = ({
       </EuiPageSideBar>
       <EuiPageBody>
         <Switch>
-          <Route path="/" exact render={() => {
-            return <GetStartedAccordion isOpen={true} />;
-          }} />
-          <Route path={Routes.ExperimentListing} exact render={() => {
+          <Route path={Routes.Home} exact render={() => {
             return <ExperimentListingWithRoute http={http} />;
           }} />
           <Route path={Routes.QuerySetListing} exact render={() => {

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -73,19 +73,31 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
     switch (templateType) {
       case TemplateType.QuerySetComparison:
         return (
-          <ResultListComparisonForm
-            formData={formData as ResultListComparisonFormData}
-            onChange={handleChange}
-            http={http}
-          />
+          <>
+            <GetStartedAccordion isOpen={true} />
+            <EuiSpacer size="l" />
+            <ResultListComparisonForm
+              formData={formData as ResultListComparisonFormData}
+              onChange={handleChange}
+              http={http}
+            />
+          </>
         );
       case TemplateType.SearchEvaluation:
         return (
-          <PointwiseExperimentForm formData={formData as PointwiseExperimentFormData} onChange={handleChange} http={http} />
+          <>
+            <GetStartedAccordion isOpen={true} />
+            <EuiSpacer size="l" />
+            <PointwiseExperimentForm formData={formData as PointwiseExperimentFormData} onChange={handleChange} http={http} />
+          </>
         );
       case TemplateType.HybridSearchOptimizer:
         return (
-          <HybridOptimizerExperimentForm formData={formData as HybridOptimizerExperimentFormData} onChange={handleChange} http={http} />
+          <>
+            <GetStartedAccordion isOpen={true} />
+            <EuiSpacer size="l" />
+            <HybridOptimizerExperimentForm formData={formData as HybridOptimizerExperimentFormData} onChange={handleChange} http={http} />
+          </>
         );
       default:
         return null;
@@ -94,8 +106,6 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
 
   return (
     <>
-      <GetStartedAccordion isOpen={true} />
-      <EuiSpacer size="l" />
       {renderForm()}
     </>
   );

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -1,9 +1,8 @@
 import React, { useState, useEffect } from 'react';
-import { EuiButton, EuiFlexGroup, EuiFlexItem, EuiFormRow } from '@elastic/eui';
+import { EuiSpacer } from '@elastic/eui';
 import { ResultListComparisonForm } from './form/result_list_comparison_form';
 import { PointwiseExperimentForm } from './form/pointwise_experiment_form';
 import { HybridOptimizerExperimentForm } from './form/hybrid_optimizer_experiment_form';
-import { LLMForm } from './form/llm_form';
 import {
   ConfigurationFormProps,
   ConfigurationFormData,
@@ -14,6 +13,7 @@ import {
   TemplateType,
 } from './types';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
+import { GetStartedAccordion } from '../../resource_management_home/get_started_accordion';
 
 const getInitialFormData = (templateType: TemplateType): ConfigurationFormData => {
   const baseData = {
@@ -92,5 +92,11 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
     }
   };
 
-  return <>{renderForm()}</>;
+  return (
+    <>
+      <GetStartedAccordion isOpen={true} />
+      <EuiSpacer size="l" />
+      {renderForm()}
+    </>
+  );
 };

--- a/public/components/experiment_create/configuration/types.tsx
+++ b/public/components/experiment_create/configuration/types.tsx
@@ -1,3 +1,4 @@
+import { RouteTemplateType } from '../../../../common';
 import { RouteComponentProps } from 'react-router-dom';
 
 export enum TemplateType {
@@ -5,6 +6,19 @@ export enum TemplateType {
   QuerySetComparison = 'Query Set Comparison',
   SearchEvaluation = 'Search Evaluation',
   HybridSearchOptimizer = 'Hybrid Search Optimizer',
+}
+
+export const routeToTemplateType = (templateId: string) => {
+  switch (templateId) {
+    case RouteTemplateType.SingleQueryComparison:
+      return TemplateType.SingleQueryComparison;
+    case RouteTemplateType.QuerySetComparison:
+      return TemplateType.QuerySetComparison;
+    case RouteTemplateType.SearchEvaluation:
+      return TemplateType.SearchEvaluation;
+    case RouteTemplateType.HybridOptimizer:
+      return TemplateType.HybridSearchOptimizer;
+  }
 }
 
 export interface TemplateConfigurationProps extends RouteComponentProps {

--- a/public/components/experiment_create/template_card/template_cards.tsx
+++ b/public/components/experiment_create/template_card/template_cards.tsx
@@ -15,9 +15,7 @@ import { COMPARE_SEARCH_RESULTS_TITLE, PLUGIN_NAME, Routes } from '../../../../c
 import { TemplateType } from '../configuration/types';
 
 interface TemplateCardsProps {
-  onClose: () => void;
   inputSelectedTemplate?: TemplateType | null;
-  onCardClick?: (templateId: TemplateType) => void;
   history: any;
 }
 
@@ -64,59 +62,11 @@ const RouteMap = {
   [TemplateType.HybridSearchOptimizer]: Routes.ExperimentCreateHybridOptimizer,
 }
 
-export const TemplateCards = ({ onClose, inputSelectedTemplate, onCardClick, history }: TemplateCardsProps) => {
-  const [selectedTemplate, setSelectedTemplate] = useState<TemplateType | null>(inputSelectedTemplate ?? null);
-  const { dataSourceEnabled, dataSourceManagement, setHeaderActionMenu, navigation } = useConfig();
-  const { services } = useOpenSearchDashboards();
-  const { notifications, http, chrome, savedObjects, application } = services;
-
-  const getNavGroupEnabled = chrome.navGroup.getNavGroupEnabled();
-  const parentBreadCrumbs = getNavGroupEnabled
-    ? [{ text: COMPARE_SEARCH_RESULTS_TITLE, href: '#' }]
-    : [{ text: PLUGIN_NAME, href: '#' }];
-
+export const TemplateCards = ({ history }: TemplateCardsProps) => {
   const handleCardClick = (templateId: TemplateType) => {
     history.push(RouteMap[templateId]);
   };
 
-  if (selectedTemplate === TemplateType.SingleQueryComparison) {
-    return (
-      <QueryCompareHome
-        application={application}
-        parentBreadCrumbs={parentBreadCrumbs}
-        notifications={notifications}
-        http={http}
-        navigation={navigation}
-        setBreadcrumbs={chrome.setBreadcrumbs}
-        chrome={chrome}
-        savedObjects={savedObjects}
-        dataSourceEnabled={dataSourceEnabled}
-        dataSourceManagement={dataSourceManagement}
-        setActionMenu={setHeaderActionMenu}
-        setToast={(title: string, color = 'success', text?: React.ReactNode) => {
-          if (color === 'success') {
-            notifications.toasts.addSuccess({ title, text });
-          } else if (color === 'warning') {
-            notifications.toasts.addWarning({ title, text });
-          } else if (color === 'danger') {
-            notifications.toasts.addDanger({ title, text });
-          } else {
-            notifications.toasts.add({ title, text });
-          }
-        }}
-      />
-    );
-  }
-
-  if (selectedTemplate) {
-    return (
-      <TemplateConfigurationWithRouter
-        templateType={selectedTemplate}
-        onBack={() => setSelectedTemplate(null)}
-        onClose={onClose}
-      />
-    );
-  }
   return (
     <>
       <EuiFlexItem grow={false}>

--- a/public/components/experiment_create/template_card/template_cards.tsx
+++ b/public/components/experiment_create/template_card/template_cards.tsx
@@ -11,13 +11,14 @@ import { TemplateConfigurationWithRouter } from '../configuration/template_confi
 import { Home as QueryCompareHome } from '../../query_compare/home';
 import { useConfig } from '../../../contexts/date_format_context';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
-import { COMPARE_SEARCH_RESULTS_TITLE, PLUGIN_NAME } from '../../../../common';
+import { COMPARE_SEARCH_RESULTS_TITLE, PLUGIN_NAME, Routes } from '../../../../common';
 import { TemplateType } from '../configuration/types';
 
 interface TemplateCardsProps {
   onClose: () => void;
   inputSelectedTemplate?: TemplateType | null;
   onCardClick?: (templateId: TemplateType) => void;
+  history: any;
 }
 
 const templates = [
@@ -56,7 +57,14 @@ const iconMap = {
   [TemplateType.HybridSearchOptimizer]: 'beaker',
 };
 
-export const TemplateCards = ({ onClose, inputSelectedTemplate, onCardClick }: TemplateCardsProps) => {
+const RouteMap = {
+  [TemplateType.SingleQueryComparison]: Routes.ExperimentCreateSingleQueryComparison,
+  [TemplateType.QuerySetComparison]: Routes.ExperimentCreateQuerySetComparison,
+  [TemplateType.SearchEvaluation]: Routes.ExperimentCreateSearchEvaluation,
+  [TemplateType.HybridSearchOptimizer]: Routes.ExperimentCreateHybridOptimizer,
+}
+
+export const TemplateCards = ({ onClose, inputSelectedTemplate, onCardClick, history }: TemplateCardsProps) => {
   const [selectedTemplate, setSelectedTemplate] = useState<TemplateType | null>(inputSelectedTemplate ?? null);
   const { dataSourceEnabled, dataSourceManagement, setHeaderActionMenu, navigation } = useConfig();
   const { services } = useOpenSearchDashboards();
@@ -68,8 +76,7 @@ export const TemplateCards = ({ onClose, inputSelectedTemplate, onCardClick }: T
     : [{ text: PLUGIN_NAME, href: '#' }];
 
   const handleCardClick = (templateId: TemplateType) => {
-    setSelectedTemplate(templateId);
-    onCardClick?.(templateId);
+    history.push(RouteMap[templateId]);
   };
 
   if (selectedTemplate === TemplateType.SingleQueryComparison) {

--- a/public/components/experiment_listing/experiment_listing.tsx
+++ b/public/components/experiment_listing/experiment_listing.tsx
@@ -13,6 +13,7 @@ import {
   EuiPageHeader,
   EuiButtonIcon,
   EuiButton,
+  EuiSpacer,
 } from '@elastic/eui';
 import {
   reactRouterNavigate,
@@ -20,11 +21,12 @@ import {
 } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../src/core/public';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { ServiceEndpoints } from '../../../common';
+import { Routes, ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
 import { useConfig } from '../../contexts/date_format_context';
 import moment from 'moment';
 import { combineResults, printType, toExperiment } from '../../types/index';
+import { TemplateCards } from '../experiment_create/template_card/template_cards';
 
 interface ExperimentListingProps extends RouteComponentProps {
   http: CoreStart['http'];
@@ -80,7 +82,7 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `/experiment/view/${experiment.id}`)}
+            {...reactRouterNavigate(history, `${Routes.ExperimentViewPrefix}/${experiment.id}`)}
           >
             {id}
           </EuiButtonEmpty>
@@ -177,22 +179,17 @@ export const ExperimentListing: React.FC<ExperimentListingProps> = ({ http, hist
     <EuiPageTemplate paddingSize="l" restrictWidth="100%">
       <EuiPageHeader
         pageTitle="Experiments"
-        description="View and manage your existing experiments. Click on a experiment id to view details."
-        rightSideItems={[
-          <EuiButton
-            onClick={() => history.push('/experiment/create')}
-            fill
-            size="s"
-            iconType="plus"
-            data-test-subj="createExperimentButton"
-            color="primary"
-          >
-            Create Experiment
-          </EuiButton>
-        ]}
+        description="Manage your existing experiments and create new ones. Click on a card to create an experiment."
       />
 
+      <EuiSpacer size="m" />
+
+      <TemplateCards history={history} onClose={() => {}} />
+
+      <EuiSpacer size="m" />
+
       <EuiFlexItem>
+        <EuiText>Click on an experiment id to view details.</EuiText>
         {error ? (
           <EuiCallOut title="Error" color="danger">
             <p>{error}</p>

--- a/public/components/judgment_listing/judgment_listing.tsx
+++ b/public/components/judgment_listing/judgment_listing.tsx
@@ -22,7 +22,7 @@ import {
 } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { DeleteModal } from '../common/DeleteModal';
 import { useConfig } from '../../contexts/date_format_context';
-import { ServiceEndpoints } from '../../../common';
+import { Routes, ServiceEndpoints } from '../../../common';
 import moment from 'moment';
 
 interface JudgmentListingProps extends RouteComponentProps {
@@ -77,7 +77,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `/judgment/view/${judgment.id}`)}
+            {...reactRouterNavigate(history, `${Routes.JudgmentViewPrefix}/${judgment.id}`)}
           >
             {name}
           </EuiButtonEmpty>
@@ -158,7 +158,7 @@ export const JudgmentListing: React.FC<JudgmentListingProps> = ({ http, history 
         description="View and manage your existing judgments. Click on a judgment list name to view details."
         rightSideItems={[
           <EuiButton
-            onClick={() => history.push('/judgment/create')}
+            onClick={() => history.push(Routes.JudgmentCreate)}
             fill
             size="s"
             iconType="plus"

--- a/public/components/query_set_listing/query_set_listing.tsx
+++ b/public/components/query_set_listing/query_set_listing.tsx
@@ -22,7 +22,7 @@ import {
   TableListView,
 } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../src/core/public';
-import { ServiceEndpoints } from '../../../common';
+import { Routes, ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
 import { useConfig } from '../../contexts/date_format_context';
 import moment from 'moment';
@@ -79,7 +79,7 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history 
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `/querySet/view/${querySet.id}`)}
+            {...reactRouterNavigate(history, `${Routes.QuerySetViewPrefix}/${querySet.id}`)}
           >
             {name}
           </EuiButtonEmpty>
@@ -175,7 +175,7 @@ export const QuerySetListing: React.FC<QuerySetListingProps> = ({ http, history 
         description="View and manage your existing query sets. Click on a query set name to view details."
         rightSideItems={[
           <EuiButton
-            onClick={() => history.push('/querySet/create')}
+            onClick={() => history.push(Routes.QuerySetCreate)}
             fill
             size="s"
             iconType="plus"

--- a/public/components/search_config_listing/search_config_listing.tsx
+++ b/public/components/search_config_listing/search_config_listing.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../../../../src/plugins/opensearch_dashboards_react/public';
 import { CoreStart } from '../../../../../src/core/public';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { ServiceEndpoints } from '../../../common';
+import { Routes, ServiceEndpoints } from '../../../common';
 import { DeleteModal } from '../common/DeleteModal';
 import { useConfig } from '../../contexts/date_format_context';
 import moment from 'moment';
@@ -60,7 +60,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
         <>
           <EuiButtonEmpty
             size="xs"
-            {...reactRouterNavigate(history, `/searchConfiguration/view/${searchConfiguration.id}`)}
+            {...reactRouterNavigate(history, `${Routes.SearchConfigurationViewPrefix}/${searchConfiguration.id}`)}
           >
             {name}
           </EuiButtonEmpty>
@@ -174,7 +174,7 @@ export const SearchConfigurationListing: React.FC<SearchConfigurationListingProp
                 to view details."
         rightSideItems={[
           <EuiButton
-            onClick={() => history.push('/searchConfiguration/create')}
+            onClick={() => history.push(Routes.SearchConfigurationCreate)}
             fill
             size="s"
             iconType="plus"


### PR DESCRIPTION
### Description
This PR makes the experiment listing page the home page for the plugin. This PR also moves the experiment creation template cards to the experiment listing screen to make experiment creation visible.

Lastly, the help screen of the former home page (you need to create query sets, etc) has been moved to the experiment creation pages. These help cards are the same for all experiments at the moment. The style of the cards could be improved.

This work required the refactoring of the experiment create cards. The navigation has been simplified, clicking on the cards just updates the create route for the specific experiment type.

We also added an enum type that centralizes the UI routes.

### Screenshots
New landing page for the plugin:
<img width="1621" alt="Screenshot 2025-06-03 at 18 04 14" src="https://github.com/user-attachments/assets/150fa679-bd6e-4e97-8344-0f8c7d42f659" />

Creation pages now show the help cards that were previously shown in the overview page, also note the more detailed route for experiment creation:
<img width="1617" alt="Screenshot 2025-06-03 at 18 04 36" src="https://github.com/user-attachments/assets/968cde46-32ba-49ba-a356-8118b5d0d9b6" />


### Misc

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
