### PR TITLE
Adding experiment type HYBRID_OPTIMIZER

### DIFF
--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -287,6 +287,28 @@ export const toExperiment = (source: any): ParseResult<Experiment> => {
       },
     };
 
+  case 'HYBRID_OPTIMIZER':
+    if (source.searchConfigurationList.length < 1) {
+      return parseError("Missing search configuration for hybrid optimizer (searchConfigurationList).");
+    }
+    if (!source.judgmentList || source.judgmentList.length < 1) {
+      return parseError("Missing judgment for hybrid optimizer (judgmentList).");
+    }
+    return {
+      success: true,
+      data: {
+        type: "HYBRID_OPTIMIZER",
+        status: source.status,
+        id: source.id,
+        k: source.size,
+        querySetId: source.querySetId,
+        timestamp: source.timestamp,
+        searchConfigurationId: source.searchConfigurationList[0],
+        judgmentId: source.judgmentList[0],
+        size
+      }
+    };
+
     default:
       return parseError(`Unknown experiment type: ${source.type}`);
   }


### PR DESCRIPTION
### Description
Fixed runtime error for scenario when system has at least one experiment of type HYBRID_OPTIMIZER. 

Before this change, if I click on Experiments

![image](https://github.com/user-attachments/assets/32ab9e5a-33ab-4cde-8713-8bc3daf7538d)

and following is in console:

```
experiment_listing.tsx:114 
(2) ['Unknown experiment type: HYBRID_OPTIMIZER', 'Unknown experiment type: HYBRID_OPTIMIZER']
0: "Unknown experiment type: HYBRID_OPTIMIZER"
1: "Unknown experiment type: HYBRID_OPTIMIZER"
length: 2
```

After the fix

![image](https://github.com/user-attachments/assets/a7b49662-9334-4e99-8415-6e93c5825704)


### Issues Resolved
_List any issues this PR will resolve, e.g. Closes [...]._ 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
