### PR TITLE
Fixed runtime error when creating experiment of type Hybrid_optimizer

### DIFF
--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -34,11 +34,16 @@ const getInitialFormData = (templateType: TemplateType): ConfigurationFormData =
         judgmentList: [],
         type: "POINTWISE_EVALUATION",
       };
+    case TemplateType.HybridSearchOptimizer:
+      return {
+        ...baseData,
+        judgmentList: [],
+        type: "HYBRID_OPTIMIZER",
+      };
     default:
       return (baseData as unknown) as
         | ResultListComparisonFormData
         | PointwiseExperimentFormData
-        | HybridOptimizerExperimentFormData
         | LLMFormData;
   }
 };

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -93,6 +93,7 @@ export type ExperimentBase = {
 export type Experiment =
   | PairwiseComparisonExperiment
   | EvaluationExperiment
+  | HybridOptimizerExperiment
 
 export type PairwiseComparisonExperiment =
   (ExperimentBase & {
@@ -107,12 +108,21 @@ export type EvaluationExperiment =
     judgmentId: string;
   })
 
+export type HybridOptimizerExperiment =
+  (ExperimentBase & {
+    type: "HYBRID_OPTIMIZER";
+    searchConfigurationId: string;
+    judgmentId: string;
+  })
+
 export const printType = (type: string) => {
   switch (type) {
     case "PAIRWISE_COMPARISON":
       return "Comparison";
     case "POINTWISE_EVALUATION":
       return "Evaluation";
+    case "HYBRID_OPTIMIZER":
+      return "HybridOptimizer";
     default:
       return "Unknown";
   }

--- a/public/types/index.ts
+++ b/public/types/index.ts
@@ -122,7 +122,7 @@ export const printType = (type: string) => {
     case "POINTWISE_EVALUATION":
       return "Evaluation";
     case "HYBRID_OPTIMIZER":
-      return "HybridOptimizer";
+      return "Hybrid Optimizer";
     default:
       return "Unknown";
   }


### PR DESCRIPTION
### Description
Fixed error when user is trying to create experiment for Hybrid Optimizer.

Current flow: set parameters for hybrid optimizer experiment

![image](https://github.com/user-attachments/assets/2423f56d-893a-464a-a758-4ae1c8be28b9)

then runtime exception is returned and experiment is not created
![image](https://github.com/user-attachments/assets/5b604151-983b-4d04-b7e8-3d9646018107)

details of the error:
```
Failed to create experiment
Bad Request
null_pointer_exception
Name is null

Error: Bad Request
    at Fetch.fetchResponse (http://localhost:5601/qkw/9007199254740991/bundles/core/core.entry.js:32742:13)
    at async interceptResponse (http://localhost:5601/qkw/9007199254740991/bundles/core/core.entry.js:33210:10)
    at async http://localhost:5601/qkw/9007199254740991/bundles/core/core.entry.js:32637:39
```

With this fix the experiment is created successfully.

![image](https://github.com/user-attachments/assets/84f22a94-f1d5-47a1-817e-b99a9f38eb3c)
 
### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
