### PR TITLE
Introduce experiment specific Get Started steps

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -26,7 +26,7 @@ import JudgmentView from './judgment_view/judgment_view';
 import { QuerySetCreateWithRouter } from './query_set_create/query_set_create';
 import { SearchConfigurationCreateWithRouter } from './search_config_create/search_config_create';
 import { JudgmentCreateWithRouter } from './judgment_create/judgment_create';
-import { GetStartedAccordion } from './resource_management_home/get_started_accordion';
+import { GetStartedAccordion } from './experiment_create/get_started_accordion';
 import { TemplateType, routeToTemplateType } from './experiment_create/configuration/types';
 import { TemplateConfigurationWithRouter } from './experiment_create/configuration/template_configuration';
 

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -15,6 +15,7 @@ import {
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { GetStartedAccordion } from '../../resource_management_home/get_started_accordion';
 
+
 const getInitialFormData = (templateType: TemplateType): ConfigurationFormData => {
   const baseData = {
     querySetId: '',
@@ -79,7 +80,7 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
       case TemplateType.QuerySetComparison:
         return (
           <>
-            <GetStartedAccordion isOpen={true} />
+            <GetStartedAccordion isOpen={true} templateType={templateType} />
             <EuiSpacer size="l" />
             <ResultListComparisonForm
               formData={formData as ResultListComparisonFormData}
@@ -91,7 +92,7 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
       case TemplateType.SearchEvaluation:
         return (
           <>
-            <GetStartedAccordion isOpen={true} />
+            <GetStartedAccordion isOpen={true} templateType={templateType} />
             <EuiSpacer size="l" />
             <PointwiseExperimentForm formData={formData as PointwiseExperimentFormData} onChange={handleChange} http={http} />
           </>
@@ -99,7 +100,7 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
       case TemplateType.HybridSearchOptimizer:
         return (
           <>
-            <GetStartedAccordion isOpen={true} />
+            <GetStartedAccordion isOpen={true} templateType={templateType} />
             <EuiSpacer size="l" />
             <HybridOptimizerExperimentForm formData={formData as HybridOptimizerExperimentFormData} onChange={handleChange} http={http} />
           </>

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -13,7 +13,7 @@ import {
   TemplateType,
 } from './types';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
-import { GetStartedAccordion } from '../../resource_management_home/get_started_accordion';
+import { GetStartedAccordion } from '../get_started_accordion';
 
 const getInitialFormData = (templateType: TemplateType): ConfigurationFormData => {
   const baseData = {

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -15,7 +15,6 @@ import {
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { GetStartedAccordion } from '../../resource_management_home/get_started_accordion';
 
-
 const getInitialFormData = (templateType: TemplateType): ConfigurationFormData => {
   const baseData = {
     querySetId: '',

--- a/public/components/experiment_create/get_started_accordion.tsx
+++ b/public/components/experiment_create/get_started_accordion.tsx
@@ -14,7 +14,7 @@ import {
   EuiTitle,
   EuiAccordion,
 } from '@elastic/eui';
-import { TemplateType } from '../experiment_create/configuration/types';
+import { TemplateType } from './configuration/types';
 
 interface GetStartedAccordionProps {
   isOpen?: boolean;

--- a/public/components/resource_management_home/get_started_accordion.tsx
+++ b/public/components/resource_management_home/get_started_accordion.tsx
@@ -14,16 +14,349 @@ import {
   EuiTitle,
   EuiAccordion,
 } from '@elastic/eui';
+import { TemplateType } from '../experiment_create/configuration/types';
 
 interface GetStartedAccordionProps {
   isOpen?: boolean;
+  templateType?: TemplateType;
 }
 
 export function GetStartedAccordion(props: GetStartedAccordionProps) {
+  const { isOpen, templateType = TemplateType.QuerySetComparison } = props;
+  
+  const renderContent = () => {
+    switch (templateType) {
+      case TemplateType.QuerySetComparison:
+        return (
+          <EuiFlexGroup direction="row">
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>1. Select your Query Set</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Select query set that are created either by sampling real live queries or upload the queries that you're interested in.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>2. Gather your Search Configuration</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  You need to have TWO Search Configurations that you want to compare against each other already defined.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>3. Select your Evaluation Configuration</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  You can select to evaluate your experiment either by customized calculator or user behavior or LLM.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>4. Evaluate your Experiment</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Set based metrics like Jaccard and RBO will be calculated to compare the Search Configurations.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      
+      case TemplateType.SearchEvaluation:
+        return (
+          <EuiFlexGroup direction="row">
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>1. Select your Query Set</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Select the query set containing queries you want to evaluate for search relevance.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>2. Select your Search Configuration</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Select the search configuration that will be evaluated for relevance.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>3. Select your Judgment List</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Pick the judgment list to use in evaluating search results.  You need judgment lists that overlap with your Query Set.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>4. Run Evaluation</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Execute the evaluation to generate metrics about your search configuration's performance.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      
+      case TemplateType.HybridSearchOptimizer:
+        return (
+          <EuiFlexGroup direction="row">
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>1. Select your Query Set</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Select the query set containing queries you want to use to optimize lexical versus vector weighting for optimal search results in your Hybrid query.
+                  They should be representative of your overall user query distributions.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>2. Configure Hybrid Search</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Set up the hybrid search parameters in a Search Configuraiton you want to optimize.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>3. Select your Judgment List</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Pick the judgment list to use in evaluating search results. Typically you want implicit judgments sourced from <a href="https://docs.opensearch.org/docs/latest/search-plugins/ubi/index/">actual user behavior</a>.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>4. Run Optimizer</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Execute the optimizer to find the best weights and configurations for your hybrid search.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>5. Assess Results</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Download and install a OpenSearch Dashboard that lets you evaluate the results of the Optimizer run.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>            
+          </EuiFlexGroup>
+        );
+      
+      case TemplateType.SingleQueryComparison:
+        return (
+          <EuiFlexGroup direction="row">
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>1. Define Your Query</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Specify a single query that you want to compare results for.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>2. Configure Search Parameters</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Set up different search configurations to compare against each other.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>3. Define Comparison Metrics</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Choose the metrics that will be used to compare the different search configurations.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>4. Compare Results</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  View and analyze the differences between search configurations for your query.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+      
+      default:
+        return (
+          <EuiFlexGroup direction="row">
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>1. Select your Query Sets</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Select query sets that created either by sampling real live queries or upload the queries that you're interested in.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>2. Gather your Search Configuration</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Import the query template along with other configurations for search.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>3. Select your Evaluation Configuration</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  You can select to evaluate your experiment either by customized calculator or user behavior or LLM.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+            <EuiFlexItem>
+              <EuiCard
+                layout="horizontal"
+                title={
+                  <EuiTitle size="s">
+                    <h3>4. Evaluate your Experiment</h3>
+                  </EuiTitle>
+                }
+              >
+                <EuiText>
+                  Document-based judgement scores will be collect and aggregated into evaluation metrics.
+                </EuiText>
+              </EuiCard>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        );
+    }
+  };
+
   return (
     <EuiAccordion
       style={{ marginBottom: '-16px' }}
-      initialIsOpen={props.isOpen}
+      initialIsOpen={isOpen}
       id={`accordionGetStarted`}
       buttonContent={
         <EuiFlexGroup direction="row">
@@ -35,64 +368,7 @@ export function GetStartedAccordion(props: GetStartedAccordionProps) {
     >
       <EuiSpacer size="s" />
       <EuiFlexItem>
-        <EuiFlexGroup direction="row">
-          <EuiFlexItem>
-            <EuiCard
-              layout="horizontal"
-              title={
-                <EuiTitle size="s">
-                  <h3>1. Select your Query Sets</h3>
-                </EuiTitle>
-              }
-            >
-              <EuiText>
-                Select query sets that created either by sampling real live queries or upload the queries that you're interested in.
-              </EuiText>
-            </EuiCard>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiCard
-              layout="horizontal"
-              title={
-                <EuiTitle size="s">
-                  <h3>2. Gather your Search Configuration</h3>
-                </EuiTitle>
-              }
-            >
-              <EuiText>
-                Import the query template along with other configurations for search.
-              </EuiText>
-            </EuiCard>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiCard
-              layout="horizontal"
-              title={
-                <EuiTitle size="s">
-                  <h3>3. Select your Evaluation Configuration</h3>
-                </EuiTitle>
-              }
-            >
-              <EuiText>
-                You can select to evaluate your experiment either by customized calculator or user behavior or LLM.
-              </EuiText>
-            </EuiCard>
-          </EuiFlexItem>
-          <EuiFlexItem>
-            <EuiCard
-              layout="horizontal"
-              title={
-                <EuiTitle size="s">
-                  <h3>4. Evaluate your Experiment</h3>
-                </EuiTitle>
-              }
-            >
-              <EuiText>
-                Document-based judgement scores will be collect and aggregated into evaluation metrics.
-              </EuiText>
-            </EuiCard>
-          </EuiFlexItem>
-        </EuiFlexGroup>
+        {renderContent()}
       </EuiFlexItem>
     </EuiAccordion>
   );


### PR DESCRIPTION
### Description
Each experiment now has it's own "Get Started" that is specific to what a user should expect.

I want it to be sort of a quick overview of the experiment so you know what you are getting into...

Hybrid has a step 5 that is the pointer to the dashboard you would install idea...

### Issues Resolved
n/a

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
