### PR TITLE
Use the standard backend plugin url pattern

### DIFF
--- a/common/index.ts
+++ b/common/index.ts
@@ -24,10 +24,10 @@ export enum ServiceEndpoints {
 }
 
 export enum BackendEndpoints {
-  QuerySets = '/_plugins/search_relevance/query_sets',
-  SearchConfigurations = '/_plugins/search_relevance/search_configurations',
-  Judgments = '/_plugins/search_relevance/judgments',
-  Experiments = '/_plugins/search_relevance/experiments',
+  QuerySets = '/_plugins/_search_relevance/query_sets',
+  SearchConfigurations = '/_plugins/_search_relevance/search_configurations',
+  Judgments = '/_plugins/_search_relevance/judgments',
+  Experiments = '/_plugins/_search_relevance/experiments',
 }
 
 export const SEARCH_API = '/_search';


### PR DESCRIPTION
### Description
Update the URL's that we call for the backend `search-relevance` plugin's api to follow the standard.

This must be paired with https://github.com/opensearch-project/search-relevance/pull/62

### Issues Resolved
Part of https://github.com/opensearch-project/search-relevance/issues/49


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
