### PR TITLE
add form validation to the three experiment types.

### DIFF
--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -1,19 +1,151 @@
-import React, { useState, useEffect, useRef } from 'react';
+import React, { useState, useEffect, useRef, useImperativeHandle, forwardRef } from 'react';
 import { EuiSpacer, EuiCallOut } from '@elastic/eui';
 import { ResultListComparisonForm, ResultListComparisonFormRef } from './form/result_list_comparison_form';
 import { PointwiseExperimentForm, PointwiseExperimentFormRef } from './form/pointwise_experiment_form';
 import { HybridOptimizerExperimentForm, HybridOptimizerExperimentFormRef } from './form/hybrid_optimizer_experiment_form';
 import {
-  ConfigurationFormProps,
   ConfigurationFormData,
   ResultListComparisonFormData,
   PointwiseExperimentFormData,
   HybridOptimizerExperimentFormData,
-  LLMFormData,
   TemplateType,
 } from './types';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { GetStartedAccordion } from '../get_started_accordion';
+
+export interface ConfigurationFormRef {
+  validateAndGetData: () => { data: ConfigurationFormData | null; isValid: boolean }; // Updated return type
+  clearFormErrors: () => void;
+}
+
+interface ConfigurationFormProps {
+  templateType: TemplateType;
+}
+
+export const ConfigurationForm = forwardRef<ConfigurationFormRef, ConfigurationFormProps>(
+  ({ templateType }, ref) => {
+    const {
+      services: { http },
+    } = useOpenSearchDashboards();
+
+    // `formData` in ConfigurationForm should primarily reflect the *initial* state
+    // and then be updated by `handleChange` which gets called by children.
+    // However, the true source of "current" validated data will now be the child's ref.
+    const [formData, setFormData] = useState<ConfigurationFormData>(getInitialFormData(templateType));
+    const [showFormError, setShowFormError] = useState<boolean>(false);
+
+    const activeFormRef = useRef<PointwiseExperimentFormRef | ResultListComparisonFormRef | HybridOptimizerExperimentFormRef | null>(null);
+
+    useImperativeHandle(ref, () => ({
+      validateAndGetData: () => {
+        let isValid = false;
+        let validatedData: ConfigurationFormData | null = null;
+
+        if (activeFormRef.current) {
+          const result = activeFormRef.current.validateAndSetErrors(); // Call child's validation
+          isValid = result.isValid;
+          validatedData = result.data as ConfigurationFormData; // Cast to general type
+        }
+
+        setShowFormError(!isValid);
+        return { data: validatedData, isValid };
+      },
+      clearFormErrors: () => {
+        setShowFormError(false);
+        if (activeFormRef.current) {
+          activeFormRef.current.clearAllErrors();
+        }
+      }
+    }));
+
+    useEffect(() => {
+      // When templateType changes, reset form data and clear any displayed errors
+      setFormData(getInitialFormData(templateType));
+      setShowFormError(false);
+      // The individual forms will clear their errors when their formData prop changes
+      // or when `clearFormErrors` is called via the main ref.
+    }, [templateType]);
+
+
+    const handleChange = (field: string, value: any) => {
+      setFormData((prev) => ({
+        ...prev,
+        [field]: value,
+      }));
+      setShowFormError(false);
+    };
+
+    const renderForm = () => {
+      // When templateType changes, the previous child component unmounts and this ref
+      // will naturally become null until the new component mounts and assigns itself.
+      // Explicitly setting to null here is okay, but React's ref handling generally
+      // takes care of it for conditionally rendered components.
+      activeFormRef.current = null;
+
+      switch (templateType) {
+        case TemplateType.QuerySetComparison:
+          return (
+            <>
+              <GetStartedAccordion isOpen={true} />
+              <EuiSpacer size="l" />
+              <ResultListComparisonForm
+                formData={formData as ResultListComparisonFormData}
+                onChange={handleChange}
+                http={http}
+                ref={activeFormRef as React.Ref<ResultListComparisonFormRef>}
+              />
+            </>
+          );
+        case TemplateType.SearchEvaluation:
+          return (
+            <>
+              <GetStartedAccordion isOpen={true} />
+              <EuiSpacer size="l" />
+              <PointwiseExperimentForm
+                formData={formData as PointwiseExperimentFormData}
+                onChange={handleChange}
+                http={http}
+                ref={activeFormRef as React.Ref<PointwiseExperimentFormRef>}
+              />
+            </>
+          );
+        case TemplateType.HybridSearchOptimizer:
+          return (
+            <>
+              <GetStartedAccordion isOpen={true} />
+              <EuiSpacer size="l" />
+              <HybridOptimizerExperimentForm
+                formData={formData as HybridOptimizerExperimentFormData}
+                onChange={handleChange}
+                http={http}
+                ref={activeFormRef as React.Ref<HybridOptimizerExperimentFormRef>}
+              />
+            </>
+          );
+        default:
+          console.warn(`No form component defined for templateType: ${templateType}`);
+          return null;
+      }
+    };
+
+    return (
+      <>
+        {showFormError && (
+          <EuiCallOut
+            title="Please address the highlighted errors."
+            color="danger"
+            iconType="cross"
+            size="s"
+          >
+          </EuiCallOut>
+        )}
+        <EuiSpacer size="s" />
+        {renderForm()}
+      </>
+    );
+  }
+);
+
 
 const getInitialFormData = (templateType: TemplateType): ConfigurationFormData => {
   const baseCommonData = {
@@ -47,145 +179,4 @@ const getInitialFormData = (templateType: TemplateType): ConfigurationFormData =
             type: "UNKNOWN_TYPE" as any,
         } as ConfigurationFormData;
   }
-};
-
-interface ConfigurationFormProps {
-  templateType: TemplateType;
-  onSave: (data: ConfigurationFormData, isValid: boolean) => void;
-  validateTrigger: number;
-}
-
-export const ConfigurationForm = ({ templateType, onSave, validateTrigger }: ConfigurationFormProps) => {
-  const {
-    services: { http },
-  } = useOpenSearchDashboards();
-
-  const [formData, setFormData] = useState<ConfigurationFormData>(getInitialFormData(templateType));
-  const [showFormError, setShowFormError] = useState<boolean>(false);
-
-  const pointwiseFormRef = useRef<PointwiseExperimentFormRef>(null);
-  const resultListFormRef = useRef<ResultListComparisonFormRef>(null);
-  const hybridOptimizerFormRef = useRef<HybridOptimizerExperimentFormRef>(null);
-
-  useEffect(() => {
-    setFormData(getInitialFormData(templateType));
-    setShowFormError(false);
-    if (pointwiseFormRef.current) {
-      pointwiseFormRef.current.clearAllErrors();
-    }
-    if (resultListFormRef.current) {
-      resultListFormRef.current.clearAllErrors();
-    }
-    if (hybridOptimizerFormRef.current) {
-      hybridOptimizerFormRef.current.clearAllErrors();
-    }
-  }, [templateType]);
-
-  useEffect(() => {
-    if (validateTrigger > 0) {
-      let isValid = true;
-      switch (templateType) {
-        case TemplateType.SearchEvaluation:
-          if (pointwiseFormRef.current) {
-            isValid = pointwiseFormRef.current.validateAndSetErrors();
-          } else {
-            isValid = false;
-          }
-          break;
-        case TemplateType.QuerySetComparison:
-          if (resultListFormRef.current) {
-            isValid = resultListFormRef.current.validateAndSetErrors();
-          } else {
-            isValid = false;
-          }
-          break;
-        case TemplateType.HybridSearchOptimizer:
-          if (hybridOptimizerFormRef.current) {
-            isValid = hybridOptimizerFormRef.current.validateAndSetErrors();
-          } else {
-            isValid = false;
-          }
-          break;
-        default:
-          isValid = false;
-          break;
-      }
-      onSave(formData, isValid);
-      setShowFormError(!isValid);
-    } else {
-      onSave(formData, false);
-      setShowFormError(false);
-    }
-  }, [validateTrigger, templateType, formData, onSave]);
-
-  const handleChange = (field: string, value: any) => {
-    setFormData((prev) => ({
-      ...prev,
-      [field]: value,
-    }));
-    setShowFormError(false);
-  };
-
-  const renderForm = () => {
-    switch (templateType) {
-      case TemplateType.QuerySetComparison:
-        return (
-          <>
-            <GetStartedAccordion isOpen={true} templateType={templateType} />
-            <EuiSpacer size="l" />
-            <ResultListComparisonForm
-              formData={formData as ResultListComparisonFormData}
-              onChange={handleChange}
-              http={http}
-              ref={resultListFormRef}
-            />
-          </>
-        );
-      case TemplateType.SearchEvaluation:
-        return (
-          <>
-            <GetStartedAccordion isOpen={true} templateType={templateType} />
-            <EuiSpacer size="l" />
-            <PointwiseExperimentForm
-              formData={formData as PointwiseExperimentFormData}
-              onChange={handleChange}
-              http={http}
-              ref={pointwiseFormRef}
-            />
-          </>
-        );
-      case TemplateType.HybridSearchOptimizer:
-        return (
-          <>
-            <GetStartedAccordion isOpen={true} templateType={templateType} />
-            <EuiSpacer size="l" />
-            <HybridOptimizerExperimentForm
-              formData={formData as HybridOptimizerExperimentFormData}
-              onChange={handleChange}
-              http={http}
-              ref={hybridOptimizerFormRef}
-            />
-          </>
-        );
-      default:
-        console.warn(`No form component defined for templateType: ${templateType}`);
-        return null;
-    }
-  };
-
-  return (
-    <>
-      {showFormError && (
-        <EuiCallOut
-          // Changed the title here
-          title="Please address the highlighted errors."
-          color="danger"
-          size="l"
-        >
-        </EuiCallOut>
-      )}
-      <EuiSpacer size="s" />
-      {renderForm()}
-    </>
-  );
 };

--- a/public/components/experiment_create/configuration/configuration_form.tsx
+++ b/public/components/experiment_create/configuration/configuration_form.tsx
@@ -1,8 +1,8 @@
-import React, { useState, useEffect } from 'react';
-import { EuiSpacer } from '@elastic/eui';
-import { ResultListComparisonForm } from './form/result_list_comparison_form';
-import { PointwiseExperimentForm } from './form/pointwise_experiment_form';
-import { HybridOptimizerExperimentForm } from './form/hybrid_optimizer_experiment_form';
+import React, { useState, useEffect, useRef } from 'react';
+import { EuiSpacer, EuiCallOut } from '@elastic/eui';
+import { ResultListComparisonForm, ResultListComparisonFormRef } from './form/result_list_comparison_form';
+import { PointwiseExperimentForm, PointwiseExperimentFormRef } from './form/pointwise_experiment_form';
+import { HybridOptimizerExperimentForm, HybridOptimizerExperimentFormRef } from './form/hybrid_optimizer_experiment_form';
 import {
   ConfigurationFormProps,
   ConfigurationFormData,
@@ -16,7 +16,7 @@ import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearc
 import { GetStartedAccordion } from '../get_started_accordion';
 
 const getInitialFormData = (templateType: TemplateType): ConfigurationFormData => {
-  const baseData = {
+  const baseCommonData = {
     querySetId: '',
     size: 10,
     searchConfigurationList: [],
@@ -25,53 +25,105 @@ const getInitialFormData = (templateType: TemplateType): ConfigurationFormData =
   switch (templateType) {
     case TemplateType.QuerySetComparison:
       return {
-        ...baseData,
+        ...baseCommonData,
         type: "PAIRWISE_COMPARISON",
-      };
+      } as ResultListComparisonFormData;
     case TemplateType.SearchEvaluation:
       return {
-        ...baseData,
+        ...baseCommonData,
         judgmentList: [],
         type: "POINTWISE_EVALUATION",
-      };
+      } as PointwiseExperimentFormData;
     case TemplateType.HybridSearchOptimizer:
       return {
-        ...baseData,
+        ...baseCommonData,
         judgmentList: [],
         type: "HYBRID_OPTIMIZER",
-      };
+      } as HybridOptimizerExperimentFormData;
     default:
-      return (baseData as unknown) as
-        | ResultListComparisonFormData
-        | PointwiseExperimentFormData
-        | LLMFormData;
+        console.warn(`Attempted to get initial form data for unhandled TemplateType: ${templateType}. Returning a minimal base configuration.`);
+        return {
+            ...baseCommonData,
+            type: "UNKNOWN_TYPE" as any,
+        } as ConfigurationFormData;
   }
 };
 
-export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormProps) => {
+interface ConfigurationFormProps {
+  templateType: TemplateType;
+  onSave: (data: ConfigurationFormData, isValid: boolean) => void;
+  validateTrigger: number;
+}
+
+export const ConfigurationForm = ({ templateType, onSave, validateTrigger }: ConfigurationFormProps) => {
   const {
     services: { http },
   } = useOpenSearchDashboards();
 
   const [formData, setFormData] = useState<ConfigurationFormData>(getInitialFormData(templateType));
+  const [showFormError, setShowFormError] = useState<boolean>(false);
+
+  const pointwiseFormRef = useRef<PointwiseExperimentFormRef>(null);
+  const resultListFormRef = useRef<ResultListComparisonFormRef>(null);
+  const hybridOptimizerFormRef = useRef<HybridOptimizerExperimentFormRef>(null);
 
   useEffect(() => {
     setFormData(getInitialFormData(templateType));
+    setShowFormError(false);
+    if (pointwiseFormRef.current) {
+      pointwiseFormRef.current.clearAllErrors();
+    }
+    if (resultListFormRef.current) {
+      resultListFormRef.current.clearAllErrors();
+    }
+    if (hybridOptimizerFormRef.current) {
+      hybridOptimizerFormRef.current.clearAllErrors();
+    }
   }, [templateType]);
 
   useEffect(() => {
-    onSave(formData);
-  }, [formData, onSave]);
+    if (validateTrigger > 0) {
+      let isValid = true;
+      switch (templateType) {
+        case TemplateType.SearchEvaluation:
+          if (pointwiseFormRef.current) {
+            isValid = pointwiseFormRef.current.validateAndSetErrors();
+          } else {
+            isValid = false;
+          }
+          break;
+        case TemplateType.QuerySetComparison:
+          if (resultListFormRef.current) {
+            isValid = resultListFormRef.current.validateAndSetErrors();
+          } else {
+            isValid = false;
+          }
+          break;
+        case TemplateType.HybridSearchOptimizer:
+          if (hybridOptimizerFormRef.current) {
+            isValid = hybridOptimizerFormRef.current.validateAndSetErrors();
+          } else {
+            isValid = false;
+          }
+          break;
+        default:
+          isValid = false;
+          break;
+      }
+      onSave(formData, isValid);
+      setShowFormError(!isValid);
+    } else {
+      onSave(formData, false);
+      setShowFormError(false);
+    }
+  }, [validateTrigger, templateType, formData, onSave]);
 
-  const handleChange = (field: string, value: string) => {
+  const handleChange = (field: string, value: any) => {
     setFormData((prev) => ({
       ...prev,
       [field]: value,
     }));
-  };
-
-  const handleSave = () => {
-    onSave(formData);
+    setShowFormError(false);
   };
 
   const renderForm = () => {
@@ -85,6 +137,7 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
               formData={formData as ResultListComparisonFormData}
               onChange={handleChange}
               http={http}
+              ref={resultListFormRef}
             />
           </>
         );
@@ -93,7 +146,12 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
           <>
             <GetStartedAccordion isOpen={true} templateType={templateType} />
             <EuiSpacer size="l" />
-            <PointwiseExperimentForm formData={formData as PointwiseExperimentFormData} onChange={handleChange} http={http} />
+            <PointwiseExperimentForm
+              formData={formData as PointwiseExperimentFormData}
+              onChange={handleChange}
+              http={http}
+              ref={pointwiseFormRef}
+            />
           </>
         );
       case TemplateType.HybridSearchOptimizer:
@@ -101,16 +159,32 @@ export const ConfigurationForm = ({ templateType, onSave }: ConfigurationFormPro
           <>
             <GetStartedAccordion isOpen={true} templateType={templateType} />
             <EuiSpacer size="l" />
-            <HybridOptimizerExperimentForm formData={formData as HybridOptimizerExperimentFormData} onChange={handleChange} http={http} />
+            <HybridOptimizerExperimentForm
+              formData={formData as HybridOptimizerExperimentFormData}
+              onChange={handleChange}
+              http={http}
+              ref={hybridOptimizerFormRef}
+            />
           </>
         );
       default:
+        console.warn(`No form component defined for templateType: ${templateType}`);
         return null;
     }
   };
 
   return (
     <>
+      {showFormError && (
+        <EuiCallOut
+          // Changed the title here
+          title="Please address the highlighted errors."
+          color="danger"
+          size="l"
+        >
+        </EuiCallOut>
+      )}
+      <EuiSpacer size="s" />
       {renderForm()}
     </>
   );

--- a/public/components/experiment_create/configuration/form/hybrid_optimizer_experiment_form.tsx
+++ b/public/components/experiment_create/configuration/form/hybrid_optimizer_experiment_form.tsx
@@ -1,46 +1,155 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldNumber } from '@elastic/eui';
-import { ResultListComparisonFormData, IndexOption } from '../types';
+import { IndexOption, HybridOptimizerExperimentFormData } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
 import { SearchConfigForm } from '../search_configuration_form';
 import { QuerySetsComboBox } from './query_sets_combo_box';
 import { JudgmentsComboBox } from './judgments_combo_box';
 
+export interface HybridOptimizerExperimentFormRef {
+  validateAndSetErrors: () => boolean;
+  clearAllErrors: () => void;
+}
+
 interface HybridOptimizerExperimentFormProps {
-  formData: ResultListComparisonFormData;
-  onChange: (field: keyof ResultListComparisonFormData, value: any) => void;
+  formData: HybridOptimizerExperimentFormData;
+  onChange: (field: keyof HybridOptimizerExperimentFormData, value: any) => void;
   http: CoreStart['http'];
 }
 
-export const HybridOptimizerExperimentForm = ({
-  formData,
-  onChange,
-  http,
-}: HybridOptimizerExperimentFormProps) => {
-  const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
-  const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
-  const [k, setK] = useState<number>(10);
-  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
+export const HybridOptimizerExperimentForm = forwardRef<
+  HybridOptimizerExperimentFormRef,
+  HybridOptimizerExperimentFormProps
+>(({ formData, onChange, http }, ref) => {
+  const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>(
+    formData?.querySetId
+      ? [{ label: formData.querySetId, value: formData.querySetId }]
+      : []
+  );
+  const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>(
+    Array.isArray(formData?.searchConfigurationList)
+      ? formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
+      : []
+  );
+  const [k, setK] = useState<number>(
+    formData?.size !== undefined && formData?.size !== null ? formData.size : 10
+  );
+  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>(
+    Array.isArray(formData?.judgmentList)
+      ? formData.judgmentList.map((judgment) => ({ label: judgment, value: judgment }))
+      : []
+  );
 
-  const handleQuerySetsChange = (selectedOptions: any[]) => {
+  const [querySetError, setQuerySetError] = useState<string[]>([]);
+  const [kError, setKError] = useState<string[]>([]);
+  const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
+  const [judgmentError, setJudgmentError] = useState<string[]>([]);
+
+  const clearAllErrors = () => {
+    setQuerySetError([]);
+    setKError([]);
+    setSearchConfigError([]);
+    setJudgmentError([]);
+  };
+
+  useEffect(() => {
+    setQuerySetOptions(
+      formData?.querySetId
+        ? [{ label: formData.querySetId, value: formData.querySetId }]
+        : []
+    );
+    setSelectedSearchConfigs(
+      Array.isArray(formData?.searchConfigurationList)
+        ? formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
+        : []
+    );
+    setK(formData?.size !== undefined && formData?.size !== null ? formData.size : 10);
+    setJudgmentOptions(
+      Array.isArray(formData?.judgmentList)
+        ? formData.judgmentList.map((judgment) => ({ label: judgment, value: judgment }))
+        : []
+    );
+    clearAllErrors();
+  }, [formData]);
+
+  const validateAndSetErrors = (): boolean => {
+    let isValid = true;
+
+    // Validate Query Set
+    if (!querySetOptions.length) {
+      setQuerySetError(['Please select a query set.']);
+      isValid = false;
+    } else {
+      setQuerySetError([]);
+    }
+
+    // Validate K Value
+    if (isNaN(k) || k < 1) {
+      setKError(['K value must be a positive number.']);
+      isValid = false;
+    } else {
+      setKError([]);
+    }
+
+    // Validate Search Configuration (maxNumberOfOptions is 1, so exactly one is needed)
+    if (selectedSearchConfigs.length !== 1) {
+      setSearchConfigError(['Please select exactly one search configuration.']);
+      isValid = false;
+    } else {
+      setSearchConfigError([]);
+    }
+
+    // Validate Judgments
+    if (!judgmentOptions.length) {
+      setJudgmentError(['Please select at least one judgment list.']);
+      isValid = false;
+    } else {
+      setJudgmentError([]);
+    }
+
+    return isValid;
+  };
+
+  useImperativeHandle(ref, () => ({
+    validateAndSetErrors,
+    clearAllErrors,
+  }));
+
+  const handleQuerySetsChange = (selectedOptions: IndexOption[]) => {
     setQuerySetOptions(selectedOptions || []);
     onChange('querySetId', selectedOptions?.[0]?.value);
+    // Clear error immediately on valid change IF an error was previously set
+    if (selectedOptions.length > 0 && querySetError.length > 0) {
+      setQuerySetError([]);
+    }
   };
 
   const handleJudgmentsChange = (selectedOptions: IndexOption[]) => {
     setJudgmentOptions(selectedOptions || []);
     onChange('judgmentList', selectedOptions.map((o) => o.value));
+    // Clear error immediately on valid change IF an error was previously set
+    if (selectedOptions.length > 0 && judgmentError.length > 0) {
+      setJudgmentError([]);
+    }
   };
 
   const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);
     setK(value);
     onChange('size', value);
+    // Clear error immediately on valid change IF an error was previously set
+    if (!isNaN(value) && value >= 1 && kError.length > 0) {
+      setKError([]);
+    }
   };
 
   const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
     setSelectedSearchConfigs(selectedOptions);
     onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
+    // Clear error immediately on valid change (assuming exactly 1 is needed)
+    if (selectedOptions.length === 1 && searchConfigError.length > 0) {
+      setSearchConfigError([]);
+    }
   };
 
   return (
@@ -48,40 +157,68 @@ export const HybridOptimizerExperimentForm = ({
       <EuiFlexItem>
         <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
           <EuiFlexItem grow={4}>
-            <QuerySetsComboBox
-              selectedOptions={querySetOptions}
-              onChange={handleQuerySetsChange}
-              http={http}
-            />
+            <EuiFormRow
+              label="Query Set"
+              isInvalid={querySetError.length > 0}
+              error={querySetError}
+            >
+              <QuerySetsComboBox
+                selectedOptions={querySetOptions}
+                onChange={handleQuerySetsChange}
+                http={http}
+                hideLabel={true}
+              />
+            </EuiFormRow>
           </EuiFlexItem>
           <EuiFlexItem grow={1}>
-            <EuiFormRow label="K Value" helpText="The number of documents to include from the result list.">
+            <EuiFormRow
+              label="K Value"
+              helpText="The number of documents to include from the result list."
+              isInvalid={kError.length > 0}
+              error={kError}
+            >
               <EuiFieldNumber
                 placeholder="Enter k value"
                 value={k}
                 onChange={handleKChange}
                 min={1}
                 fullWidth
+                isInvalid={kError.length > 0}
               />
             </EuiFormRow>
           </EuiFlexItem>
         </EuiFlexGroup>
       </EuiFlexItem>
       <EuiFlexItem>
-        <SearchConfigForm
-          selectedOptions={selectedSearchConfigs}
-          onChange={handleSearchConfigChange}
-          http={http}
-          maxNumberOfOptions={1}
-        />
+        <EuiFormRow
+          label="Search Configuration"
+          helpText="Select exactly one search configuration."
+          isInvalid={searchConfigError.length > 0}
+          error={searchConfigError}
+        >
+          <SearchConfigForm
+            selectedOptions={selectedSearchConfigs}
+            onChange={handleSearchConfigChange}
+            http={http}
+            maxNumberOfOptions={1} // Set to 1 as per HybridOptimizer requirements
+            hideLabel={true}
+          />
+        </EuiFormRow>
       </EuiFlexItem>
       <EuiFlexItem>
-        <JudgmentsComboBox
-          selectedOptions={judgmentOptions}
-          onChange={handleJudgmentsChange}
-          http={http}
-        />
+        <EuiFormRow
+          label="Judgments"
+          isInvalid={judgmentError.length > 0}
+          error={judgmentError}
+        >
+          <JudgmentsComboBox
+            selectedOptions={judgmentOptions}
+            onChange={handleJudgmentsChange}
+            http={http}
+            hideLabel={true}
+          />
+        </EuiFormRow>
       </EuiFlexItem>
     </EuiFlexGroup>
   );
-};
+});

--- a/public/components/experiment_create/configuration/form/hybrid_optimizer_experiment_form.tsx
+++ b/public/components/experiment_create/configuration/form/hybrid_optimizer_experiment_form.tsx
@@ -7,7 +7,7 @@ import { QuerySetsComboBox } from './query_sets_combo_box';
 import { JudgmentsComboBox } from './judgments_combo_box';
 
 export interface HybridOptimizerExperimentFormRef {
-  validateAndSetErrors: () => boolean;
+  validateAndSetErrors: () => { isValid: boolean; data: HybridOptimizerExperimentFormData; };
   clearAllErrors: () => void;
 }
 
@@ -21,24 +21,10 @@ export const HybridOptimizerExperimentForm = forwardRef<
   HybridOptimizerExperimentFormRef,
   HybridOptimizerExperimentFormProps
 >(({ formData, onChange, http }, ref) => {
-  const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>(
-    formData?.querySetId
-      ? [{ label: formData.querySetId, value: formData.querySetId }]
-      : []
-  );
-  const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>(
-    Array.isArray(formData?.searchConfigurationList)
-      ? formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
-      : []
-  );
-  const [k, setK] = useState<number>(
-    formData?.size !== undefined && formData?.size !== null ? formData.size : 10
-  );
-  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>(
-    Array.isArray(formData?.judgmentList)
-      ? formData.judgmentList.map((judgment) => ({ label: judgment, value: judgment }))
-      : []
-  );
+  const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
+  const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
+  const [k, setK] = useState<number>(10);
+  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
 
   const [querySetError, setQuerySetError] = useState<string[]>([]);
   const [kError, setKError] = useState<string[]>([]);
@@ -69,14 +55,23 @@ export const HybridOptimizerExperimentForm = forwardRef<
         ? formData.judgmentList.map((judgment) => ({ label: judgment, value: judgment }))
         : []
     );
-    clearAllErrors();
+    clearAllErrors(); // Clear errors on formData prop change
   }, [formData]);
 
-  const validateAndSetErrors = (): boolean => {
+  const validateAndSetErrors = (): { isValid: boolean; data: HybridOptimizerExperimentFormData; } => {
     let isValid = true;
 
+    // Construct the current data object from internal states for validation
+    const currentData: HybridOptimizerExperimentFormData = {
+      querySetId: querySetOptions[0]?.value || '',
+      size: k,
+      searchConfigurationList: selectedSearchConfigs.map(c => c.value),
+      judgmentList: judgmentOptions.map(j => j.value),
+      type: formData.type, // Preserve the 'type' from the initial formData
+    };
+
     // Validate Query Set
-    if (!querySetOptions.length) {
+    if (!currentData.querySetId) {
       setQuerySetError(['Please select a query set.']);
       isValid = false;
     } else {
@@ -84,15 +79,15 @@ export const HybridOptimizerExperimentForm = forwardRef<
     }
 
     // Validate K Value
-    if (isNaN(k) || k < 1) {
+    if (isNaN(currentData.size) || currentData.size < 1) {
       setKError(['K value must be a positive number.']);
       isValid = false;
     } else {
       setKError([]);
     }
 
-    // Validate Search Configuration (maxNumberOfOptions is 1, so exactly one is needed)
-    if (selectedSearchConfigs.length !== 1) {
+    // Validate Search Configuration (exactly one is needed for HybridOptimizer)
+    if (currentData.searchConfigurationList.length !== 1) {
       setSearchConfigError(['Please select exactly one search configuration.']);
       isValid = false;
     } else {
@@ -100,14 +95,14 @@ export const HybridOptimizerExperimentForm = forwardRef<
     }
 
     // Validate Judgments
-    if (!judgmentOptions.length) {
+    if (!currentData.judgmentList.length) {
       setJudgmentError(['Please select at least one judgment list.']);
       isValid = false;
     } else {
       setJudgmentError([]);
     }
 
-    return isValid;
+    return { isValid, data: currentData }; // Return the validation status AND the current data
   };
 
   useImperativeHandle(ref, () => ({
@@ -117,8 +112,10 @@ export const HybridOptimizerExperimentForm = forwardRef<
 
   const handleQuerySetsChange = (selectedOptions: IndexOption[]) => {
     setQuerySetOptions(selectedOptions || []);
-    onChange('querySetId', selectedOptions?.[0]?.value);
-    // Clear error immediately on valid change IF an error was previously set
+    const newValue = selectedOptions?.[0]?.value || '';
+    if (formData.querySetId !== newValue) {
+      onChange('querySetId', newValue);
+    }
     if (selectedOptions.length > 0 && querySetError.length > 0) {
       setQuerySetError([]);
     }
@@ -126,8 +123,10 @@ export const HybridOptimizerExperimentForm = forwardRef<
 
   const handleJudgmentsChange = (selectedOptions: IndexOption[]) => {
     setJudgmentOptions(selectedOptions || []);
-    onChange('judgmentList', selectedOptions.map((o) => o.value));
-    // Clear error immediately on valid change IF an error was previously set
+    const newValues = selectedOptions.map((o) => o.value);
+    if (JSON.stringify(formData.judgmentList) !== JSON.stringify(newValues)) {
+      onChange('judgmentList', newValues);
+    }
     if (selectedOptions.length > 0 && judgmentError.length > 0) {
       setJudgmentError([]);
     }
@@ -136,8 +135,9 @@ export const HybridOptimizerExperimentForm = forwardRef<
   const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = parseInt(e.target.value, 10);
     setK(value);
-    onChange('size', value);
-    // Clear error immediately on valid change IF an error was previously set
+    if (formData.size !== value) {
+      onChange('size', value);
+    }
     if (!isNaN(value) && value >= 1 && kError.length > 0) {
       setKError([]);
     }
@@ -145,7 +145,10 @@ export const HybridOptimizerExperimentForm = forwardRef<
 
   const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
     setSelectedSearchConfigs(selectedOptions);
-    onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
+    const newValues = selectedOptions.map((o) => o.value);
+    if (JSON.stringify(formData.searchConfigurationList) !== JSON.stringify(newValues)) {
+      onChange('searchConfigurationList', newValues);
+    }
     // Clear error immediately on valid change (assuming exactly 1 is needed)
     if (selectedOptions.length === 1 && searchConfigError.length > 0) {
       setSearchConfigError([]);

--- a/public/components/experiment_create/configuration/form/judgments_combo_box.tsx
+++ b/public/components/experiment_create/configuration/form/judgments_combo_box.tsx
@@ -4,16 +4,20 @@ import { IndexOption } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../../../common';
 
+interface JudgmentOption extends IndexOption {}
+
 interface JudgmentsComboBoxProps {
   selectedOptions: JudgmentOption[];
   onChange: (selectedOptions: JudgmentOption[]) => void;
   http: CoreStart['http'];
+  hideLabel?: boolean;
 }
 
 export const JudgmentsComboBox = ({
   selectedOptions,
   onChange,
   http,
+  hideLabel,
 }: JudgmentsComboBoxProps) => {
   const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -38,20 +42,29 @@ export const JudgmentsComboBox = ({
     fetchJudgments();
   }, [http]);
 
-  return (
-    <EuiFormRow label="Judgments">
-      <EuiComboBox
-        placeholder={isLoading ? 'Loading...' : 'Select judgment list'}
-        options={judgmentOptions}
-        selectedOptions={selectedOptions}
-        onChange={onChange}
-        isClearable
-        isInvalid={selectedOptions.length === 0}
-        singleSelection={{ asPlainText: true }}
-        isLoading={isLoading}
-        async
-        fullWidth
-      />
-    </EuiFormRow>
+  const comboBoxComponent = (
+    <EuiComboBox
+      placeholder={isLoading ? 'Loading...' : 'Select judgment list'}
+      options={judgmentOptions}
+      selectedOptions={selectedOptions}
+      onChange={onChange}
+      isClearable
+      isInvalid={selectedOptions.length === 0}
+      singleSelection={{ asPlainText: true }}
+      isLoading={isLoading}
+      async
+      fullWidth
+    />
   );
+
+  // Conditionally render EuiFormRow based on the hideLabel prop
+  if (hideLabel) {
+    return comboBoxComponent; // If hideLabel is true, just return the EuiComboBox
+  } else {
+    return (
+      <EuiFormRow label="Judgments"> {/* If hideLabel is false or undefined, render with EuiFormRow */}
+        {comboBoxComponent}
+      </EuiFormRow>
+    );
+  }
 };

--- a/public/components/experiment_create/configuration/form/pointwise_experiment_form.tsx
+++ b/public/components/experiment_create/configuration/form/pointwise_experiment_form.tsx
@@ -13,7 +13,7 @@ interface PointwiseExperimentFormProps {
 }
 
 export interface PointwiseExperimentFormRef {
-  validateAndSetErrors: () => boolean;
+  validateAndSetErrors: () => { isValid: boolean; data: PointwiseExperimentFormData; };
   clearAllErrors: () => void;
 }
 
@@ -37,38 +37,30 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
     };
 
     useEffect(() => {
-      if (formData.querySetId) {
-        setQuerySetOptions([{ label: formData.querySetId, value: formData.querySetId }]);
-      } else {
-        setQuerySetOptions([]);
-      }
-      if (formData.size !== undefined && formData.size !== null) {
-        setK(formData.size);
-      } else {
-        setK(10);
-      }
-      if (formData.searchConfigurationList && formData.searchConfigurationList.length > 0) {
-        setSelectedSearchConfigs(
-          formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
-        );
-      } else {
-        setSelectedSearchConfigs([]);
-      }
-      if (formData.judgmentList && formData.judgmentList.length > 0) {
-        setJudgmentOptions(
-          (formData.judgmentList as string[]).map((judgment) => ({ label: judgment, value: judgment }))
-        );
-      } else {
-        setJudgmentOptions([]);
-      }
+      setQuerySetOptions(formData.querySetId ? [{ label: formData.querySetId, value: formData.querySetId }] : []);
+      setK(formData.size ?? 10);
+      setSelectedSearchConfigs(
+        formData.searchConfigurationList ? formData.searchConfigurationList.map((config) => ({ label: config, value: config })) : []
+      );
+      setJudgmentOptions(
+        (formData.judgmentList as string[])?.length > 0 ? (formData.judgmentList as string[]).map((judgment) => ({ label: judgment, value: judgment })) : []
+      );
       clearAllErrors();
-    }, [formData]);
+    }, [formData]); // Dependency on formData ensures re-initialization when parent's formData changes
 
-    const validateAndSetErrors = (): boolean => {
+
+    const validateAndSetErrors = (): { isValid: boolean; data: PointwiseExperimentFormData; } => {
       let isValid = true;
+      const currentData: PointwiseExperimentFormData = {
+        querySetId: querySetOptions[0]?.value || '',
+        size: k,
+        searchConfigurationList: selectedSearchConfigs.map(c => c.value),
+        judgmentList: judgmentOptions.map(j => j.value),
+        type: formData.type // Preserve the type from the initial formData
+      };
 
       // Validate Query Set
-      if (!querySetOptions.length) {
+      if (!currentData.querySetId) { // Validate against currentData
         setQuerySetError(['Please select a query set.']);
         isValid = false;
       } else {
@@ -76,7 +68,7 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
       }
 
       // Validate K Value
-      if (isNaN(k) || k < 1) {
+      if (isNaN(currentData.size) || currentData.size < 1) { // Validate against currentData
         setKError(['K value must be a positive number.']);
         isValid = false;
       } else {
@@ -84,7 +76,7 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
       }
 
       // Validate Search Configuration
-      if (!selectedSearchConfigs.length) {
+      if (currentData.searchConfigurationList.length === 0) { // Validate against currentData
         setSearchConfigError(['Please select at least one search configuration.']);
         isValid = false;
       } else {
@@ -92,14 +84,14 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
       }
 
       // Validate Judgments
-      if (!judgmentOptions.length) {
+      if (currentData.judgmentList.length === 0) { // Validate against currentData
         setJudgmentError(['Please select at least one judgment list.']);
         isValid = false;
       } else {
         setJudgmentError([]);
       }
 
-      return isValid;
+      return { isValid, data: currentData }; // Return the validation result and the current data
     };
 
     // Expose the validateAndSetErrors and clearAllErrors functions to the parent via ref
@@ -110,8 +102,10 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
 
     const handleQuerySetsChange = (selectedOptions: IndexOption[]) => {
       setQuerySetOptions(selectedOptions || []);
-      onChange('querySetId', selectedOptions?.[0]?.value);
-      // Clear error immediately on valid change IF an error was previously set
+      const newValue = selectedOptions?.[0]?.value || '';
+      if (formData.querySetId !== newValue) {
+        onChange('querySetId', newValue);
+      }
       if (selectedOptions.length > 0 && querySetError.length > 0) {
         setQuerySetError([]);
       }
@@ -119,8 +113,10 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
 
     const handleJudgmentsChange = (selectedOptions: IndexOption[]) => {
       setJudgmentOptions(selectedOptions || []);
-      onChange('judgmentList', selectedOptions.map((o) => o.value));
-      // Clear error immediately on valid change IF an error was previously set
+      const newValues = selectedOptions.map((o) => o.value);
+      if (JSON.stringify(formData.judgmentList) !== JSON.stringify(newValues)) {
+        onChange('judgmentList', newValues);
+      }
       if (selectedOptions.length > 0 && judgmentError.length > 0) {
         setJudgmentError([]);
       }
@@ -129,8 +125,9 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
     const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = parseInt(e.target.value, 10);
       setK(value);
-      onChange('size', value);
-      // Clear error immediately on valid change IF an error was previously set
+      if (formData.size !== value) {
+        onChange('size', value);
+      }
       if (!isNaN(value) && value >= 1 && kError.length > 0) {
         setKError([]);
       }
@@ -138,8 +135,10 @@ export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, Po
 
     const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
       setSelectedSearchConfigs(selectedOptions);
-      onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
-      // Clear error immediately on valid change IF an error was previously set
+      const newValues = selectedOptions.map((o) => o.value);
+      if (JSON.stringify(formData.searchConfigurationList) !== JSON.stringify(newValues)) {
+        onChange('searchConfigurationList', newValues);
+      }
       if (selectedOptions.length > 0 && searchConfigError.length > 0) {
         setSearchConfigError([]);
       }

--- a/public/components/experiment_create/configuration/form/pointwise_experiment_form.tsx
+++ b/public/components/experiment_create/configuration/form/pointwise_experiment_form.tsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldNumber } from '@elastic/eui';
 import { ResultListComparisonFormData, IndexOption } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
@@ -12,76 +12,206 @@ interface PointwiseExperimentFormProps {
   http: CoreStart['http'];
 }
 
-export const PointwiseExperimentForm = ({
-  formData,
-  onChange,
-  http,
-}: PointwiseExperimentFormProps) => {
-  const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
-  const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
-  const [k, setK] = useState<number>(10);
-  const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
+export interface PointwiseExperimentFormRef {
+  validateAndSetErrors: () => boolean;
+  clearAllErrors: () => void;
+}
 
-  const handleQuerySetsChange = (selectedOptions: any[]) => {
-    setQuerySetOptions(selectedOptions || []);
-    onChange('querySetId', selectedOptions?.[0]?.value);
-  };
+export const PointwiseExperimentForm = forwardRef<PointwiseExperimentFormRef, PointwiseExperimentFormProps>(
+  ({ formData, onChange, http }, ref) => {
+    const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
+    const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
+    const [k, setK] = useState<number>(10);
+    const [judgmentOptions, setJudgmentOptions] = useState<IndexOption[]>([]);
 
-  const handleJudgmentsChange = (selectedOptions: IndexOption[]) => {
-    setJudgmentOptions(selectedOptions || []);
-    onChange('judgmentList', selectedOptions.map((o) => o.value));
-  };
+    const [querySetError, setQuerySetError] = useState<string[]>([]);
+    const [kError, setKError] = useState<string[]>([]);
+    const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
+    const [judgmentError, setJudgmentError] = useState<string[]>([]);
 
-  const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value, 10);
-    setK(value);
-    onChange('size', value);
-  };
+    const clearAllErrors = () => {
+      setQuerySetError([]);
+      setKError([]);
+      setSearchConfigError([]);
+      setJudgmentError([]);
+    };
 
-  const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
-    setSelectedSearchConfigs(selectedOptions);
-    onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
-  };
+    useEffect(() => {
+      if (formData.querySetId) {
+        setQuerySetOptions([{ label: formData.querySetId, value: formData.querySetId }]);
+      } else {
+        setQuerySetOptions([]);
+      }
+      if (formData.size !== undefined && formData.size !== null) {
+        setK(formData.size);
+      } else {
+        setK(10);
+      }
+      if (formData.searchConfigurationList && formData.searchConfigurationList.length > 0) {
+        setSelectedSearchConfigs(
+          formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
+        );
+      } else {
+        setSelectedSearchConfigs([]);
+      }
+      if (formData.judgmentList && formData.judgmentList.length > 0) {
+        setJudgmentOptions(
+          (formData.judgmentList as string[]).map((judgment) => ({ label: judgment, value: judgment }))
+        );
+      } else {
+        setJudgmentOptions([]);
+      }
+      clearAllErrors();
+    }, [formData]);
 
-  return (
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem>
-        <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
-          <EuiFlexItem grow={4}>
-            <QuerySetsComboBox
-              selectedOptions={querySetOptions}
-              onChange={handleQuerySetsChange}
+    const validateAndSetErrors = (): boolean => {
+      let isValid = true;
+
+      // Validate Query Set
+      if (!querySetOptions.length) {
+        setQuerySetError(['Please select a query set.']);
+        isValid = false;
+      } else {
+        setQuerySetError([]);
+      }
+
+      // Validate K Value
+      if (isNaN(k) || k < 1) {
+        setKError(['K value must be a positive number.']);
+        isValid = false;
+      } else {
+        setKError([]);
+      }
+
+      // Validate Search Configuration
+      if (!selectedSearchConfigs.length) {
+        setSearchConfigError(['Please select at least one search configuration.']);
+        isValid = false;
+      } else {
+        setSearchConfigError([]);
+      }
+
+      // Validate Judgments
+      if (!judgmentOptions.length) {
+        setJudgmentError(['Please select at least one judgment list.']);
+        isValid = false;
+      } else {
+        setJudgmentError([]);
+      }
+
+      return isValid;
+    };
+
+    // Expose the validateAndSetErrors and clearAllErrors functions to the parent via ref
+    useImperativeHandle(ref, () => ({
+      validateAndSetErrors,
+      clearAllErrors,
+    }));
+
+    const handleQuerySetsChange = (selectedOptions: IndexOption[]) => {
+      setQuerySetOptions(selectedOptions || []);
+      onChange('querySetId', selectedOptions?.[0]?.value);
+      // Clear error immediately on valid change IF an error was previously set
+      if (selectedOptions.length > 0 && querySetError.length > 0) {
+        setQuerySetError([]);
+      }
+    };
+
+    const handleJudgmentsChange = (selectedOptions: IndexOption[]) => {
+      setJudgmentOptions(selectedOptions || []);
+      onChange('judgmentList', selectedOptions.map((o) => o.value));
+      // Clear error immediately on valid change IF an error was previously set
+      if (selectedOptions.length > 0 && judgmentError.length > 0) {
+        setJudgmentError([]);
+      }
+    };
+
+    const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseInt(e.target.value, 10);
+      setK(value);
+      onChange('size', value);
+      // Clear error immediately on valid change IF an error was previously set
+      if (!isNaN(value) && value >= 1 && kError.length > 0) {
+        setKError([]);
+      }
+    };
+
+    const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
+      setSelectedSearchConfigs(selectedOptions);
+      onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
+      // Clear error immediately on valid change IF an error was previously set
+      if (selectedOptions.length > 0 && searchConfigError.length > 0) {
+        setSearchConfigError([]);
+      }
+    };
+
+    return (
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
+            <EuiFlexItem grow={4}>
+              <EuiFormRow
+                label="Query Set"
+                isInvalid={querySetError.length > 0} // Only invalid if there's an error message
+                error={querySetError}
+              >
+                <QuerySetsComboBox
+                  selectedOptions={querySetOptions}
+                  onChange={handleQuerySetsChange}
+                  http={http}
+                  hideLabel={true}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={1}>
+              <EuiFormRow
+                label="K Value"
+                helpText="The number of documents to include from the result list."
+                isInvalid={kError.length > 0} // Only invalid if there's an error message
+                error={kError}
+              >
+                <EuiFieldNumber
+                  placeholder="Enter k value"
+                  value={k}
+                  onChange={handleKChange}
+                  min={1}
+                  fullWidth
+                  isInvalid={kError.length > 0} // Also for the input field itself
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow
+            label="Search Configuration"
+            isInvalid={searchConfigError.length > 0} // Only invalid if there's an error message
+            error={searchConfigError}
+          >
+            <SearchConfigForm
+              selectedOptions={selectedSearchConfigs}
+              onChange={handleSearchConfigChange}
               http={http}
+              maxNumberOfOptions={1}
+              hideLabel={true}
             />
-          </EuiFlexItem>
-          <EuiFlexItem grow={1}>
-            <EuiFormRow label="K Value" helpText="The number of documents to include from the result list.">
-              <EuiFieldNumber
-                placeholder="Enter k value"
-                value={k}
-                onChange={handleKChange}
-                min={1}
-                fullWidth
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <SearchConfigForm
-          selectedOptions={selectedSearchConfigs}
-          onChange={handleSearchConfigChange}
-          http={http}
-          maxNumberOfOptions={1}
-        />
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <JudgmentsComboBox
-          selectedOptions={judgmentOptions}
-          onChange={handleJudgmentsChange}
-          http={http}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-};
+          </EuiFormRow>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          <EuiFormRow
+            label="Judgments"
+            isInvalid={judgmentError.length > 0} // Only invalid if there's an error message
+            error={judgmentError}
+          >
+            <JudgmentsComboBox
+              selectedOptions={judgmentOptions}
+              onChange={handleJudgmentsChange}
+              http={http}
+              hideLabel={true}
+            />
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+);

--- a/public/components/experiment_create/configuration/form/query_sets_combo_box.tsx
+++ b/public/components/experiment_create/configuration/form/query_sets_combo_box.tsx
@@ -8,12 +8,14 @@ interface QuerySetsComboBoxProps {
   selectedOptions: IndexOption[];
   onChange: (selectedOptions: IndexOption[]) => void;
   http: CoreStart['http'];
+  hideLabel?: boolean;
 }
 
 export const QuerySetsComboBox = ({
   selectedOptions,
   onChange,
   http,
+  hideLabel,
 }: QuerySetsComboBoxProps) => {
   const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
   const [isLoading, setIsLoading] = useState<boolean>(true);
@@ -38,20 +40,29 @@ export const QuerySetsComboBox = ({
     fetchQuerySets();
   }, [http]);
 
-  return (
-    <EuiFormRow label="Query Sets">
-      <EuiComboBox
-        placeholder={isLoading ? 'Loading...' : 'Select query sets'}
-        options={querySetOptions}
-        selectedOptions={selectedOptions}
-        onChange={onChange}
-        isClearable
-        isInvalid={selectedOptions.length === 0}
-        singleSelection={{ asPlainText: true }}
-        isLoading={isLoading}
-        async
-        fullWidth
-      />
-    </EuiFormRow>
+  const comboBoxComponent = (
+    <EuiComboBox
+      placeholder={isLoading ? 'Loading...' : 'Select query sets'}
+      options={querySetOptions}
+      selectedOptions={selectedOptions}
+      onChange={onChange}
+      isClearable
+      isInvalid={selectedOptions.length === 0}
+      singleSelection={{ asPlainText: true }}
+      isLoading={isLoading}
+      async
+      fullWidth
+    />
   );
-}; 
+
+  // Conditionally render EuiFormRow based on the hideLabel prop
+  if (hideLabel) {
+    return comboBoxComponent; // If hideLabel is true, just return the EuiComboBox
+  } else {
+    return (
+      <EuiFormRow label="Query Sets"> {/* If hideLabel is false or undefined, render with EuiFormRow */}
+        {comboBoxComponent}
+      </EuiFormRow>
+    );
+  }
+};

--- a/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
+++ b/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
@@ -1,13 +1,12 @@
-import React, { useState, useEffect, useImperativeHandle, forwardRef } from 'react'; // Add forwardRef and useImperativeHandle
+import React, { useState, useEffect, useImperativeHandle, forwardRef } from 'react';
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldNumber } from '@elastic/eui';
 import { IndexOption, ResultListComparisonFormData } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
 import { SearchConfigForm } from '../search_configuration_form';
 import { QuerySetsComboBox } from './query_sets_combo_box';
 
-// 1. Define a Ref interface for ResultListComparisonForm
 export interface ResultListComparisonFormRef {
-  validateAndSetErrors: () => boolean;
+  validateAndSetErrors: () => { isValid: boolean; data: ResultListComparisonFormData; };
   clearAllErrors: () => void;
 }
 
@@ -17,37 +16,22 @@ interface ResultListComparisonFormProps {
   http: CoreStart['http'];
 }
 
-// 2. Make ResultListComparisonForm a forwardRef component
 export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, ResultListComparisonFormProps>(
   ({ formData, onChange, http }, ref) => {
-    // Defensive initialization of states from formData
-    const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>(
-      formData?.querySetId
-        ? [{ label: formData.querySetId, value: formData.querySetId }]
-        : []
-    );
-    const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>(
-      Array.isArray(formData?.searchConfigurationList)
-        ? formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
-        : []
-    );
-    const [k, setK] = useState<number>(
-      formData?.size !== undefined && formData?.size !== null ? formData.size : 10
-    );
+    const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
+    const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
+    const [k, setK] = useState<number>(10);
 
-    // 3. Add local validation states (errors)
     const [querySetError, setQuerySetError] = useState<string[]>([]);
     const [kError, setKError] = useState<string[]>([]);
     const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
 
-    // 4. Function to clear all local error states
     const clearAllErrors = () => {
       setQuerySetError([]);
       setKError([]);
       setSearchConfigError([]);
     };
 
-    // useEffect to update internal state if formData prop changes (e.g., template type switch)
     useEffect(() => {
       setQuerySetOptions(
         formData?.querySetId
@@ -60,17 +44,21 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
           : []
       );
       setK(formData?.size !== undefined && formData?.size !== null ? formData.size : 10);
-
-      // CRUCIAL: Clear all errors when formData changes (e.g., template type switch)
       clearAllErrors();
     }, [formData]);
 
-    // 5. This function will run validation and set the error messages.
-    const validateAndSetErrors = (): boolean => {
+    const validateAndSetErrors = (): { isValid: boolean; data: ResultListComparisonFormData; } => {
       let isValid = true;
 
+      const currentData: ResultListComparisonFormData = {
+        querySetId: querySetOptions[0]?.value || '',
+        size: k,
+        searchConfigurationList: selectedSearchConfigs.map(c => c.value),
+        type: formData.type,
+      };
+
       // Validate Query Set
-      if (!querySetOptions.length) {
+      if (!currentData.querySetId) {
         setQuerySetError(['Please select a query set.']);
         isValid = false;
       } else {
@@ -78,26 +66,24 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
       }
 
       // Validate K Value
-      if (isNaN(k) || k < 1) {
+      if (isNaN(currentData.size) || currentData.size < 1) {
         setKError(['K value must be a positive number.']);
         isValid = false;
       } else {
         setKError([]);
       }
 
-      // Validate Search Configuration (assuming maxNumberOfOptions is 2, so at least 2 are needed)
-      // Adjust this validation based on the actual requirements for maxNumberOfOptions
-      if (selectedSearchConfigs.length < 2) { // Assuming 2 configurations are required for comparison
+      // Validate Search Configuration (at least two are needed for comparison)
+      if (currentData.searchConfigurationList.length < 2) {
         setSearchConfigError(['Please select at least two search configurations to compare.']);
         isValid = false;
       } else {
         setSearchConfigError([]);
       }
 
-      return isValid;
+      return { isValid, data: currentData };
     };
 
-    // Expose the validateAndSetErrors and clearAllErrors functions to the parent via ref
     useImperativeHandle(ref, () => ({
       validateAndSetErrors,
       clearAllErrors,
@@ -105,8 +91,11 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
 
     const handleQuerySetsChange = (selectedOptions: IndexOption[]) => {
       setQuerySetOptions(selectedOptions || []);
-      onChange('querySetId', selectedOptions?.[0]?.value);
-      // Clear error immediately on valid change IF an error was previously set
+      const newValue = selectedOptions?.[0]?.value || '';
+      // Optimize onChange call
+      if (formData.querySetId !== newValue) {
+        onChange('querySetId', newValue);
+      }
       if (selectedOptions.length > 0 && querySetError.length > 0) {
         setQuerySetError([]);
       }
@@ -115,8 +104,10 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
     const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
       const value = parseInt(e.target.value, 10);
       setK(value);
-      onChange('size', value);
-      // Clear error immediately on valid change
+      // Optimize onChange call
+      if (formData.size !== value) {
+        onChange('size', value);
+      }
       if (!isNaN(value) && value >= 1 && kError.length > 0) {
         setKError([]);
       }
@@ -124,8 +115,11 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
 
     const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
       setSelectedSearchConfigs(selectedOptions);
-      onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
-      // Clear error immediately on valid change (assuming at least 2 are needed)
+      const newValues = selectedOptions.map((o) => o.value);
+      // Optimize onChange call
+      if (JSON.stringify(formData.searchConfigurationList) !== JSON.stringify(newValues)) {
+        onChange('searchConfigurationList', newValues);
+      }
       if (selectedOptions.length >= 2 && searchConfigError.length > 0) {
         setSearchConfigError([]);
       }
@@ -136,10 +130,9 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
         <EuiFlexItem>
           <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
             <EuiFlexItem grow={4}>
-              {/* 7. Wrap QuerySetsComboBox in EuiFormRow for label and validation */}
               <EuiFormRow
                 label="Query Set"
-                isInvalid={querySetError.length > 0} // Only invalid if there's an error message
+                isInvalid={querySetError.length > 0}
                 error={querySetError}
               >
                 <QuerySetsComboBox
@@ -151,7 +144,6 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
               </EuiFormRow>
             </EuiFlexItem>
             <EuiFlexItem grow={1}>
-              {/* 7. Wrap EuiFieldNumber in EuiFormRow for label and validation */}
               <EuiFormRow
                 label="K Value"
                 helpText="The number of documents to include from the result list."
@@ -164,17 +156,16 @@ export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, 
                   onChange={handleKChange}
                   min={1}
                   fullWidth
-                  isInvalid={kError.length > 0} // Add isInvalid to EuiFieldNumber itself too
+                  isInvalid={kError.length > 0}
                 />
               </EuiFormRow>
             </EuiFlexItem>
           </EuiFlexGroup>
         </EuiFlexItem>
         <EuiFlexItem>
-          {/* 7. Wrap SearchConfigForm in EuiFormRow for label and validation */}
           <EuiFormRow
             label="Search Configurations"
-            helpText={`Select ${2} search configuration${2 > 1 ? 's' : ''} to compare against each other.`} // Hardcoding 2 as per SearchConfigForm prop
+            helpText={`Select ${2} search configuration${2 > 1 ? 's' : ''} to compare against each other.`}
             isInvalid={searchConfigError.length > 0}
             error={searchConfigError}
           >

--- a/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
+++ b/public/components/experiment_create/configuration/form/result_list_comparison_form.tsx
@@ -1,71 +1,193 @@
-import React, { useState } from 'react';
+import React, { useState, useEffect, useImperativeHandle, forwardRef } from 'react'; // Add forwardRef and useImperativeHandle
 import { EuiFlexGroup, EuiFlexItem, EuiFormRow, EuiFieldNumber } from '@elastic/eui';
 import { IndexOption, ResultListComparisonFormData } from '../types';
 import { CoreStart } from '../../../../../src/core/public';
 import { SearchConfigForm } from '../search_configuration_form';
 import { QuerySetsComboBox } from './query_sets_combo_box';
 
+// 1. Define a Ref interface for ResultListComparisonForm
+export interface ResultListComparisonFormRef {
+  validateAndSetErrors: () => boolean;
+  clearAllErrors: () => void;
+}
+
 interface ResultListComparisonFormProps {
+  formData: ResultListComparisonFormData;
   onChange: (field: keyof ResultListComparisonFormData, value: any) => void;
   http: CoreStart['http'];
 }
 
-export const ResultListComparisonForm = ({
-  onChange,
-  http,
-}: ResultListComparisonFormProps) => {
-  const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>([]);
-  const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>([]);
-  const [k, setK] = useState<number>(10);
+// 2. Make ResultListComparisonForm a forwardRef component
+export const ResultListComparisonForm = forwardRef<ResultListComparisonFormRef, ResultListComparisonFormProps>(
+  ({ formData, onChange, http }, ref) => {
+    // Defensive initialization of states from formData
+    const [querySetOptions, setQuerySetOptions] = useState<IndexOption[]>(
+      formData?.querySetId
+        ? [{ label: formData.querySetId, value: formData.querySetId }]
+        : []
+    );
+    const [selectedSearchConfigs, setSelectedSearchConfigs] = useState<IndexOption[]>(
+      Array.isArray(formData?.searchConfigurationList)
+        ? formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
+        : []
+    );
+    const [k, setK] = useState<number>(
+      formData?.size !== undefined && formData?.size !== null ? formData.size : 10
+    );
 
-  const handleQuerySetsChange = (selectedOptions: any[]) => {
-    setQuerySetOptions(selectedOptions || []);
-    onChange('querySetId', selectedOptions?.[0]?.value);
-  };
+    // 3. Add local validation states (errors)
+    const [querySetError, setQuerySetError] = useState<string[]>([]);
+    const [kError, setKError] = useState<string[]>([]);
+    const [searchConfigError, setSearchConfigError] = useState<string[]>([]);
 
-  const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    const value = parseInt(e.target.value, 10);
-    setK(value);
-    onChange('size', value);
-  };
+    // 4. Function to clear all local error states
+    const clearAllErrors = () => {
+      setQuerySetError([]);
+      setKError([]);
+      setSearchConfigError([]);
+    };
 
-  const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
-    setSelectedSearchConfigs(selectedOptions);
-    onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
-  };
+    // useEffect to update internal state if formData prop changes (e.g., template type switch)
+    useEffect(() => {
+      setQuerySetOptions(
+        formData?.querySetId
+          ? [{ label: formData.querySetId, value: formData.querySetId }]
+          : []
+      );
+      setSelectedSearchConfigs(
+        Array.isArray(formData?.searchConfigurationList)
+          ? formData.searchConfigurationList.map((config) => ({ label: config, value: config }))
+          : []
+      );
+      setK(formData?.size !== undefined && formData?.size !== null ? formData.size : 10);
 
-  return (
-    <EuiFlexGroup direction="column">
-      <EuiFlexItem>
-        <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
-          <EuiFlexItem grow={4}>
-            <QuerySetsComboBox
-              selectedOptions={querySetOptions}
-              onChange={handleQuerySetsChange}
+      // CRUCIAL: Clear all errors when formData changes (e.g., template type switch)
+      clearAllErrors();
+    }, [formData]);
+
+    // 5. This function will run validation and set the error messages.
+    const validateAndSetErrors = (): boolean => {
+      let isValid = true;
+
+      // Validate Query Set
+      if (!querySetOptions.length) {
+        setQuerySetError(['Please select a query set.']);
+        isValid = false;
+      } else {
+        setQuerySetError([]);
+      }
+
+      // Validate K Value
+      if (isNaN(k) || k < 1) {
+        setKError(['K value must be a positive number.']);
+        isValid = false;
+      } else {
+        setKError([]);
+      }
+
+      // Validate Search Configuration (assuming maxNumberOfOptions is 2, so at least 2 are needed)
+      // Adjust this validation based on the actual requirements for maxNumberOfOptions
+      if (selectedSearchConfigs.length < 2) { // Assuming 2 configurations are required for comparison
+        setSearchConfigError(['Please select at least two search configurations to compare.']);
+        isValid = false;
+      } else {
+        setSearchConfigError([]);
+      }
+
+      return isValid;
+    };
+
+    // Expose the validateAndSetErrors and clearAllErrors functions to the parent via ref
+    useImperativeHandle(ref, () => ({
+      validateAndSetErrors,
+      clearAllErrors,
+    }));
+
+    const handleQuerySetsChange = (selectedOptions: IndexOption[]) => {
+      setQuerySetOptions(selectedOptions || []);
+      onChange('querySetId', selectedOptions?.[0]?.value);
+      // Clear error immediately on valid change IF an error was previously set
+      if (selectedOptions.length > 0 && querySetError.length > 0) {
+        setQuerySetError([]);
+      }
+    };
+
+    const handleKChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+      const value = parseInt(e.target.value, 10);
+      setK(value);
+      onChange('size', value);
+      // Clear error immediately on valid change
+      if (!isNaN(value) && value >= 1 && kError.length > 0) {
+        setKError([]);
+      }
+    };
+
+    const handleSearchConfigChange = (selectedOptions: IndexOption[]) => {
+      setSelectedSearchConfigs(selectedOptions);
+      onChange('searchConfigurationList', selectedOptions.map((o) => o.value));
+      // Clear error immediately on valid change (assuming at least 2 are needed)
+      if (selectedOptions.length >= 2 && searchConfigError.length > 0) {
+        setSearchConfigError([]);
+      }
+    };
+
+    return (
+      <EuiFlexGroup direction="column">
+        <EuiFlexItem>
+          <EuiFlexGroup gutterSize="m" direction="row" style={{ maxWidth: 600 }}>
+            <EuiFlexItem grow={4}>
+              {/* 7. Wrap QuerySetsComboBox in EuiFormRow for label and validation */}
+              <EuiFormRow
+                label="Query Set"
+                isInvalid={querySetError.length > 0} // Only invalid if there's an error message
+                error={querySetError}
+              >
+                <QuerySetsComboBox
+                  selectedOptions={querySetOptions}
+                  onChange={handleQuerySetsChange}
+                  http={http}
+                  hideLabel={true}
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+            <EuiFlexItem grow={1}>
+              {/* 7. Wrap EuiFieldNumber in EuiFormRow for label and validation */}
+              <EuiFormRow
+                label="K Value"
+                helpText="The number of documents to include from the result list."
+                isInvalid={kError.length > 0}
+                error={kError}
+              >
+                <EuiFieldNumber
+                  placeholder="Enter k value"
+                  value={k}
+                  onChange={handleKChange}
+                  min={1}
+                  fullWidth
+                  isInvalid={kError.length > 0} // Add isInvalid to EuiFieldNumber itself too
+                />
+              </EuiFormRow>
+            </EuiFlexItem>
+          </EuiFlexGroup>
+        </EuiFlexItem>
+        <EuiFlexItem>
+          {/* 7. Wrap SearchConfigForm in EuiFormRow for label and validation */}
+          <EuiFormRow
+            label="Search Configurations"
+            helpText={`Select ${2} search configuration${2 > 1 ? 's' : ''} to compare against each other.`} // Hardcoding 2 as per SearchConfigForm prop
+            isInvalid={searchConfigError.length > 0}
+            error={searchConfigError}
+          >
+            <SearchConfigForm
+              selectedOptions={selectedSearchConfigs}
+              onChange={handleSearchConfigChange}
               http={http}
+              maxNumberOfOptions={2}
+              hideLabel={true}
             />
-          </EuiFlexItem>
-          <EuiFlexItem grow={1}>
-            <EuiFormRow label="K Value" helpText="The number of documents to include from the result list.">
-              <EuiFieldNumber
-                placeholder="Enter k value"
-                value={k}
-                onChange={handleKChange}
-                min={1}
-                fullWidth
-              />
-            </EuiFormRow>
-          </EuiFlexItem>
-        </EuiFlexGroup>
-      </EuiFlexItem>
-      <EuiFlexItem>
-        <SearchConfigForm
-          selectedOptions={selectedSearchConfigs}
-          onChange={handleSearchConfigChange}
-          http={http}
-          maxNumberOfOptions={2}
-        />
-      </EuiFlexItem>
-    </EuiFlexGroup>
-  );
-};
+          </EuiFormRow>
+        </EuiFlexItem>
+      </EuiFlexGroup>
+    );
+  }
+);

--- a/public/components/experiment_create/configuration/search_configuration_form.tsx
+++ b/public/components/experiment_create/configuration/search_configuration_form.tsx
@@ -9,9 +9,16 @@ interface SearchConfigFormProps {
   onChange: (selectedOptions: IndexOption[]) => void;
   http: CoreStart['http'];
   maxNumberOfOptions: number;
+  hideLabel?: boolean;
 }
 
-export const SearchConfigForm = ({ selectedOptions, onChange, http, maxNumberOfOptions }: SearchConfigFormProps) => {
+export const SearchConfigForm = ({
+  selectedOptions,
+  onChange,
+  http,
+  maxNumberOfOptions,
+  hideLabel,
+}: SearchConfigFormProps) => {
   const [searchConfigOptions, setSearchConfigOptions] = useState<IndexOption[]>([]);
   const [isLoadingConfigs, setIsLoadingConfigs] = useState<boolean>(true);
 
@@ -35,27 +42,36 @@ export const SearchConfigForm = ({ selectedOptions, onChange, http, maxNumberOfO
     fetchSearchConfigurations();
   }, [http]);
 
-  return (
-    <EuiFormRow
-      label="Search Configurations"
-      helpText={`Select ${maxNumberOfOptions} search configuration${maxNumberOfOptions > 1 ? 's' : ''}${maxNumberOfOptions > 1 ? ' to compare against each other' : ''}.`}
-    >
-      <EuiComboBox
-        placeholder="Select search configuration"
-        options={searchConfigOptions}
-        selectedOptions={selectedOptions}
-        onChange={(selected) => {
-          if (selected.length > maxNumberOfOptions) {
-            return;
-          }
-          onChange(selected);
-        }}
-        isClearable={true}
-        isInvalid={selectedOptions.length === 0}
-        isLoading={isLoadingConfigs}
-        multi={true}
-        fullWidth
-      />
-    </EuiFormRow>
+  const comboBoxComponent = (
+    <EuiComboBox
+      placeholder="Select search configuration"
+      options={searchConfigOptions}
+      selectedOptions={selectedOptions}
+      onChange={(selected) => {
+        if (selected.length > maxNumberOfOptions) {
+          return;
+        }
+        onChange(selected);
+      }}
+      isClearable={true}
+      isInvalid={selectedOptions.length === 0}
+      isLoading={isLoadingConfigs}
+      multi={true}
+      fullWidth
+    />
   );
+
+  // Conditionally render EuiFormRow based on the hideLabel prop
+  if (hideLabel) {
+    return comboBoxComponent; // If hideLabel is true, just return the EuiComboBox
+  } else {
+    return (
+      <EuiFormRow
+        label="Search Configurations"
+        helpText={`Select ${maxNumberOfOptions} search configuration${maxNumberOfOptions > 1 ? 's' : ''}${maxNumberOfOptions > 1 ? ' to compare against each other' : ''}.`}
+      >
+        {comboBoxComponent}
+      </EuiFormRow>
+    );
+  }
 };

--- a/public/components/experiment_create/configuration/template_configuration.tsx
+++ b/public/components/experiment_create/configuration/template_configuration.tsx
@@ -1,13 +1,13 @@
-import React, { useState } from 'react';
+import React, { useState, useRef } from 'react';
 
 import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer, EuiLoadingSpinner, EuiCallOut } from '@elastic/eui';
 import { withRouter } from 'react-router-dom';
-import { ConfigurationForm } from './configuration_form';
-import { ConfigurationActions } from './configuration_action';
-import { TemplateConfigurationProps, ConfigurationFormData, SearchConfigFromData } from './types';
-import { Routes, ServiceEndpoints } from '../../../../common';
+import { ConfigurationForm, ConfigurationFormRef } from './configuration_form';
+import { TemplateConfigurationProps, ConfigurationFormData } from './types';
+import { ServiceEndpoints } from '../../../../common';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { EuiPanel } from '@elastic/eui';
+import { ConfigurationActions } from './configuration_action';
 
 export const TemplateConfiguration = ({
   templateType,
@@ -15,58 +15,58 @@ export const TemplateConfiguration = ({
   onClose,
   history,
 }: TemplateConfigurationProps) => {
-  const [configFormData, setConfigFormData] = useState<ConfigurationFormData | null>(null);
-  const [isFormValid, setIsFormValid] = useState<boolean>(false);
   const [experimentId, setExperimentId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState<boolean>(false);
   const [showEvaluation, setShowEvaluation] = useState(false);
   const [showTemplateConfigError, setShowTemplateConfigError] = useState<boolean>(false);
-  const [validateTrigger, setValidateTrigger] = useState<number>(0);
 
-  const handleConfigSave = (data: ConfigurationFormData, isValid: boolean) => {
-    setConfigFormData(data);
-    setIsFormValid(isValid);
-  };
+  const configurationFormRef = useRef<ConfigurationFormRef>(null);
 
   const {
     services: { http, notifications },
   } = useOpenSearchDashboards();
 
   const handleNext = async () => {
-    // Increment validateTrigger to tell ConfigurationForm to validate
-    setValidateTrigger(prev => prev + 1);
-    setTimeout(async () => {
-      // Check isFormValid AFTER ConfigurationForm has had a chance to validate
-      if (!isFormValid) { // Use the updated state
+    setShowTemplateConfigError(false); // Clear previous errors
+
+    if (configurationFormRef.current) {
+      const { data, isValid } = configurationFormRef.current.validateAndGetData(); // Get data and validity directly
+
+      if (!isValid || data === null) {
         setShowTemplateConfigError(true);
         return;
       }
 
-      setShowTemplateConfigError(false); // Hide the general error if valid
+      // If we reach here, `data` is guaranteed to be valid and not null
+      try {
+        setIsCreating(true);
+        const response = await http.post(ServiceEndpoints.Experiments, {
+          body: JSON.stringify(data), // Use the validated data received from child
+        });
 
-      if (configFormData) { // configFormData should be valid if isFormValid is true
-        try {
-          setIsCreating(true);
-          const response = await http.post(ServiceEndpoints.Experiments, {
-            body: JSON.stringify(configFormData),
-          });
-
-          if (response.experiment_id) {
-            setExperimentId(response.experiment_id);
-            notifications.toasts.addSuccess(`Experiment ${response.experiment_id} created successfully`);
-            history.push(`/experiment/`);
-          } else {
-            throw new Error('No experiment ID received');
+        if (response.experiment_id) {
+          setExperimentId(response.experiment_id);
+          notifications.toasts.addSuccess(`Experiment ${response.experiment_id} created successfully`);
+          history.push(`/experiment/`);
+          if (configurationFormRef.current) {
+            configurationFormRef.current.clearFormErrors();
           }
-        } catch (err) {
-          notifications.toasts.addError(err, {
-            title: 'Failed to create experiment',
-          });
-        } finally {
-          setIsCreating(false);
+        } else {
+          throw new Error('No experiment ID received');
         }
+      } catch (err) {
+        notifications.toasts.addError(err, {
+          title: 'Failed to create experiment',
+        });
+      } finally {
+        setIsCreating(false);
       }
-    }, 0); // Use a 0ms timeout to put this on the next tick of the event loop
+    } else {
+      // This case should ideally not happen if the form is rendered,
+      // but it's a good safeguard.
+      setShowTemplateConfigError(true);
+      notifications.toasts.addError('Form component not ready. Please try again.');
+    }
   };
 
 
@@ -84,8 +84,7 @@ export const TemplateConfiguration = ({
           <EuiSpacer size="m" />
           <ConfigurationForm
             templateType={templateType}
-            onSave={handleConfigSave}
-            validateTrigger={validateTrigger} // Pass the validateTrigger prop
+            ref={configurationFormRef}
           />
         </EuiFlexItem>
 

--- a/public/components/experiment_create/configuration/template_configuration.tsx
+++ b/public/components/experiment_create/configuration/template_configuration.tsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react';
 
-import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer, EuiLoadingSpinner } from '@elastic/eui';
+import { EuiFlexItem, EuiFlexGroup, EuiTitle, EuiSpacer, EuiLoadingSpinner, EuiCallOut } from '@elastic/eui';
 import { withRouter } from 'react-router-dom';
 import { ConfigurationForm } from './configuration_form';
 import { ConfigurationActions } from './configuration_action';
@@ -8,23 +8,24 @@ import { TemplateConfigurationProps, ConfigurationFormData, SearchConfigFromData
 import { Routes, ServiceEndpoints } from '../../../../common';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { EuiPanel } from '@elastic/eui';
+
 export const TemplateConfiguration = ({
   templateType,
   onBack,
   onClose,
   history,
 }: TemplateConfigurationProps) => {
-  /**
-   * Config Form will collect querySetId along with other experiment_type related fields to generate judgments.
-   */
   const [configFormData, setConfigFormData] = useState<ConfigurationFormData | null>(null);
-
+  const [isFormValid, setIsFormValid] = useState<boolean>(false);
   const [experimentId, setExperimentId] = useState<string | null>(null);
   const [isCreating, setIsCreating] = useState<boolean>(false);
   const [showEvaluation, setShowEvaluation] = useState(false);
+  const [showTemplateConfigError, setShowTemplateConfigError] = useState<boolean>(false);
+  const [validateTrigger, setValidateTrigger] = useState<number>(0);
 
-  const handleConfigSave = (data: ConfigurationFormData) => {
+  const handleConfigSave = (data: ConfigurationFormData, isValid: boolean) => {
     setConfigFormData(data);
+    setIsFormValid(isValid);
   };
 
   const {
@@ -32,31 +33,42 @@ export const TemplateConfiguration = ({
   } = useOpenSearchDashboards();
 
   const handleNext = async () => {
-    if (configFormData) {
-      try {
-        setIsCreating(true);
-        const response = await http.post(ServiceEndpoints.Experiments, {
-          body: JSON.stringify(configFormData),
-        });
-
-        if (response.experiment_id) {
-          setExperimentId(response.experiment_id);
-          notifications.toasts.addSuccess(`Experiment ${response.experiment_id} created successfully`);
-          history.push(Routes.Home);
-        } else {
-          throw new Error('No experiment ID received');
-        }
-      } catch (err) {
-        notifications.toasts.addError(err, {
-          title: 'Failed to create experiment',
-        });
-      } finally {
-        setIsCreating(false);
+    // Increment validateTrigger to tell ConfigurationForm to validate
+    setValidateTrigger(prev => prev + 1);
+    setTimeout(async () => {
+      // Check isFormValid AFTER ConfigurationForm has had a chance to validate
+      if (!isFormValid) { // Use the updated state
+        setShowTemplateConfigError(true);
+        return;
       }
-    } else {
-      console.log('Validation failed: Please fill in all required fields');
-    }
+
+      setShowTemplateConfigError(false); // Hide the general error if valid
+
+      if (configFormData) { // configFormData should be valid if isFormValid is true
+        try {
+          setIsCreating(true);
+          const response = await http.post(ServiceEndpoints.Experiments, {
+            body: JSON.stringify(configFormData),
+          });
+
+          if (response.experiment_id) {
+            setExperimentId(response.experiment_id);
+            notifications.toasts.addSuccess(`Experiment ${response.experiment_id} created successfully`);
+            history.push(`/experiment/`);
+          } else {
+            throw new Error('No experiment ID received');
+          }
+        } catch (err) {
+          notifications.toasts.addError(err, {
+            title: 'Failed to create experiment',
+          });
+        } finally {
+          setIsCreating(false);
+        }
+      }
+    }, 0); // Use a 0ms timeout to put this on the next tick of the event loop
   };
+
 
   const handleBackToConfig = () => {
     setShowEvaluation(false);
@@ -70,7 +82,11 @@ export const TemplateConfiguration = ({
             <h2>{templateType} Experiment</h2>
           </EuiTitle>
           <EuiSpacer size="m" />
-          <ConfigurationForm templateType={templateType} onSave={handleConfigSave} />
+          <ConfigurationForm
+            templateType={templateType}
+            onSave={handleConfigSave}
+            validateTrigger={validateTrigger} // Pass the validateTrigger prop
+          />
         </EuiFlexItem>
 
         <EuiFlexItem>


### PR DESCRIPTION
PR to add input form validation for experiments. 

Changes to query set, judgment and search config component to avoid duplicate labels in input forms.

### Description
Currently an internal server error is reported when an experiment with invalid input is created. This PR now shows an error message above the input form to users.

### Issues Resolved
#60 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
