### PR TITLE
Fix navigation after experiment create

### DIFF
--- a/public/components/experiment_create/configuration/template_configuration.tsx
+++ b/public/components/experiment_create/configuration/template_configuration.tsx
@@ -5,7 +5,7 @@ import { withRouter } from 'react-router-dom';
 import { ConfigurationForm } from './configuration_form';
 import { ConfigurationActions } from './configuration_action';
 import { TemplateConfigurationProps, ConfigurationFormData, SearchConfigFromData } from './types';
-import { ServiceEndpoints } from '../../../../common';
+import { Routes, ServiceEndpoints } from '../../../../common';
 import { useOpenSearchDashboards } from '../../../../../../src/plugins/opensearch_dashboards_react/public';
 import { EuiPanel } from '@elastic/eui';
 export const TemplateConfiguration = ({
@@ -42,7 +42,7 @@ export const TemplateConfiguration = ({
         if (response.experiment_id) {
           setExperimentId(response.experiment_id);
           notifications.toasts.addSuccess(`Experiment ${response.experiment_id} created successfully`);
-          history.push(`/experiment/`);
+          history.push(Routes.Home);
         } else {
           throw new Error('No experiment ID received');
         }


### PR DESCRIPTION
### Description
Navigation after experiment creation was broken. This PR fixes this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
