### PR TITLE
Bandaid for zsr queries

### DIFF
--- a/public/components/app.tsx
+++ b/public/components/app.tsx
@@ -187,7 +187,7 @@ const SearchRelevancePage = ({
           }} />
           <Route path={Routes.ExperimentView} exact render={(props) => {
             const { entityId } = props.match.params;
-            return <ExperimentViewWithRouter http={http} id={entityId} />;
+            return <ExperimentViewWithRouter http={http} notifications={notifications} id={entityId} />;
           }} />
           <Route path={Routes.QuerySetView} exact render={(props) => {
             const { entityId } = props.match.params;

--- a/public/components/experiment_view/evaluation_experiment_view.tsx
+++ b/public/components/experiment_view/evaluation_experiment_view.tsx
@@ -63,7 +63,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
         const _querySet = _experiment && await http.get(ServiceEndpoints.QuerySets + "/" + inputExperiment.querySetId).then(sanitizeResponse);
         const _judgmentSet = _experiment && await http.get(ServiceEndpoints.Judgments + "/" + inputExperiment.judgmentId).then(sanitizeResponse);
 
-        const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]);
+        const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]).filter(Boolean);
         const query = {
             index: "search-relevance-evaluation-result",
             query: {

--- a/public/components/experiment_view/evaluation_experiment_view.tsx
+++ b/public/components/experiment_view/evaluation_experiment_view.tsx
@@ -64,6 +64,7 @@ export const EvaluationExperimentView: React.FC<EvaluationExperimentViewProps> =
         const _querySet = _experiment && await http.get(ServiceEndpoints.QuerySets + "/" + inputExperiment.querySetId).then(sanitizeResponse);
         const _judgmentSet = _experiment && await http.get(ServiceEndpoints.Judgments + "/" + inputExperiment.judgmentId).then(sanitizeResponse);
 
+        // the .filter(Boolean) is used to filter out undefineds which show up for queries that are ZSR.
         const resultIds = Object.entries(_experiment.results).map(([key, value]) => value[inputExperiment.searchConfigurationId]).filter(Boolean);
         
         const query = {

--- a/public/components/experiment_view/experiment_view.tsx
+++ b/public/components/experiment_view/experiment_view.tsx
@@ -9,7 +9,7 @@ import {
   } from '@elastic/eui';
 import React, { useCallback, useEffect, useState } from 'react';
 import { RouteComponentProps, withRouter } from 'react-router-dom';
-import { CoreStart } from '../../../../../src/core/public';
+import { CoreStart, ToastsStart } from '../../../../../src/core/public';
 import { ServiceEndpoints } from '../../../common';
 import {
   toExperiment,
@@ -19,9 +19,10 @@ import { EvaluationExperimentViewWithRouter } from './evaluation_experiment_view
 
 interface ExperimentViewProps extends RouteComponentProps<{ id: string }> {
   http: CoreStart['http'];
+  notifications: CoreStart['notifications'];
 }
 
-export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, history }) => {
+export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, notifications, id, history }) => {
   const [experiment, setExperiment] = useState<any | null>(null);
   const [error, setError] = useState<string | null>(null);
 
@@ -59,6 +60,7 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
       {experiment && experiment.type === 'PAIRWISE_COMPARISON' &&
         <PairwiseExperimentViewWithRouter
           http={http}
+          notifications={notifications}
           inputExperiment={experiment}
           history={history}
         />
@@ -66,6 +68,7 @@ export const ExperimentView: React.FC<ExperimentViewProps> = ({ http, id, histor
       {experiment && experiment.type === 'POINTWISE_EVALUATION' &&
         <EvaluationExperimentViewWithRouter
           http={http}
+          notifications={notifications}
           inputExperiment={experiment}
           history={history}
         />

--- a/public/components/resource_management_home/resource_management_tabs.tsx
+++ b/public/components/resource_management_home/resource_management_tabs.tsx
@@ -104,7 +104,7 @@ export const ResourceManagementTabs = ({
               ) : (
                 <></>
               )}
-              {entityAction === 'view' ? <ExperimentViewWithRouter http={http} id={entityId} /> : <></>}
+              {entityAction === 'view' ? <ExperimentViewWithRouter http={http} notifications={notifications} id={entityId} /> : <></>}
               {selectedSubTabs === 'create' ? <TemplateCards onClose={() => {}} /> : <></>}
             </EuiPanel>
           </>


### PR DESCRIPTION
### Description
If you have some ZSR queries, they don't show up. That is odd if you have 10 queries and only 8 or 9 show up. This tells you what happened.

![image](https://github.com/user-attachments/assets/f9032afd-6071-4cb2-8d99-a63d4acb773b)

I don't know if toasts are the right way to communicate this.   


### Issues Resolved

n/a. However, we do plan to do a deeper solution in 3.2, see https://github.com/opensearch-project/search-relevance/issues/66. This is just to get us through 3.1.



By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
For more information on following Developer Certificate of Origin and signing off your commits, please check [here](https://github.com/opensearch-project/OpenSearch/blob/main/CONTRIBUTING.md#developer-certificate-of-origin).
